### PR TITLE
chore: add Claude Code local settings

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs",
+      "Skill(commit-commands:commit-push-pr)"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` with local permission allowlist for Context7 MCP tools and commit skill

## Test plan
- [x] Verify the settings file is valid JSON
- [x] Confirm permissions are scoped to expected tools only

🤖 Generated with [Claude Code](https://claude.com/claude-code)