### PR TITLE
feat(codex): add Codex agent support to Ralph

### DIFF
--- a/.agents/skills/speckit-analyze/SKILL.md
+++ b/.agents/skills/speckit-analyze/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: "speckit-analyze"
+description: "Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/analyze.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit.implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.agents/skills/speckit-checklist/SKILL.md
+++ b/.agents/skills/speckit-checklist/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: "speckit-checklist"
+description: "Generate a custom checklist for the current feature based on user requirements."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/checklist.md"
+---
+
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit.checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-clarify/SKILL.md
+++ b/.agents/skills/speckit-clarify/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: "speckit-clarify"
+description: "Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/clarify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Post-Execution Checks
+
+**Check for extension hooks (after clarification)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-constitution/SKILL.md
+++ b/.agents/skills/speckit-constitution/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: "speckit-constitution"
+description: "Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/constitution.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-git-commit/SKILL.md
+++ b/.agents/skills/speckit-git-commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: speckit-git-commit
+description: Auto-commit changes after a Spec Kit command completes
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.commit.md
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.agents/skills/speckit-git-feature/SKILL.md
+++ b/.agents/skills/speckit-git-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: speckit-git-feature
+description: Create a feature branch with sequential or timestamp numbering
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.feature.md
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit.specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.agents/skills/speckit-git-initialize/SKILL.md
+++ b/.agents/skills/speckit-git-initialize/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-initialize
+description: Initialize a Git repository with an initial commit
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.initialize.md
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.agents/skills/speckit-git-remote/SKILL.md
+++ b/.agents/skills/speckit-git-remote/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: speckit-git-remote
+description: Detect Git remote URL for GitHub integration
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.remote.md
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.agents/skills/speckit-git-validate/SKILL.md
+++ b/.agents/skills/speckit-git-validate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-validate
+description: Validate current branch follows feature branch naming conventions
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.validate.md
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.agents/skills/speckit-implement/SKILL.md
+++ b/.agents/skills/speckit-implement/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: "speckit-implement"
+description: "Execute the implementation plan by processing and executing all tasks defined in tasks.md"
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/implement.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.agents/skills/speckit-plan/SKILL.md
+++ b/.agents/skills/speckit-plan/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: "speckit-plan"
+description: "Execute the implementation planning workflow using the plan template to generate design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/plan.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-plan.ps1 -Json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `AGENTS.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications

--- a/.agents/skills/speckit-specify/SKILL.md
+++ b/.agents/skills/speckit-specify/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: "speckit-specify"
+description: "Create or update the feature specification from a natural language feature description."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/specify.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit.plan`, `/speckit.tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit.specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 7
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. **Report completion** to the user with:
+   - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+   - `SPEC_FILE` — the spec file path
+   - Checklist results summary
+   - Readiness for the next phase (`/speckit.clarify` or `/speckit.plan`)
+
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.agents/skills/speckit-tasks/SKILL.md
+++ b/.agents/skills/speckit-tasks/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: "speckit-tasks"
+description: "Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/tasks.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.agents/skills/speckit-taskstoissues/SKILL.md
+++ b/.agents/skills/speckit-taskstoissues/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: "speckit-taskstoissues"
+description: "Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts."
+compatibility: "Requires spec-kit project structure with .specify/ directory"
+metadata:
+  author: "github-spec-kit"
+  source: "templates/commands/taskstoissues.md"
+---
+
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.claude/skills/speckit-git-commit/SKILL.md
+++ b/.claude/skills/speckit-git-commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: speckit-git-commit
+description: Auto-commit changes after a Spec Kit command completes
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.commit.md
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.claude/skills/speckit-git-feature/SKILL.md
+++ b/.claude/skills/speckit-git-feature/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: speckit-git-feature
+description: Create a feature branch with sequential or timestamp numbering
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.feature.md
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit.specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.claude/skills/speckit-git-initialize/SKILL.md
+++ b/.claude/skills/speckit-git-initialize/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-initialize
+description: Initialize a Git repository with an initial commit
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.initialize.md
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.claude/skills/speckit-git-remote/SKILL.md
+++ b/.claude/skills/speckit-git-remote/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: speckit-git-remote
+description: Detect Git remote URL for GitHub integration
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.remote.md
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.claude/skills/speckit-git-validate/SKILL.md
+++ b/.claude/skills/speckit-git-validate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-git-validate
+description: Validate current branch follows feature branch naming conventions
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: git:commands/speckit.git.validate.md
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ go.work.sum
 
 # env file
 .env
+.env*
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
 .ralph/regent-state.json

--- a/.opencode/command/speckit.analyze.md
+++ b/.opencode/command/speckit.analyze.md
@@ -1,0 +1,249 @@
+---
+description: Perform a non-destructive cross-artifact consistency and quality analysis across spec.md, plan.md, and tasks.md after task generation.
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before analysis)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Goal.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Goal
+
+Identify inconsistencies, duplications, ambiguities, and underspecified items across the three core artifacts (`spec.md`, `plan.md`, `tasks.md`) before implementation. This command MUST run only after `/speckit.tasks` has successfully produced a complete `tasks.md`.
+
+## Operating Constraints
+
+**STRICTLY READ-ONLY**: Do **not** modify any files. Output a structured analysis report. Offer an optional remediation plan (user must explicitly approve before any follow-up editing commands would be invoked manually).
+
+**Constitution Authority**: The project constitution (`.specify/memory/constitution.md`) is **non-negotiable** within this analysis scope. Constitution conflicts are automatically CRITICAL and require adjustment of the spec, plan, or tasks—not dilution, reinterpretation, or silent ignoring of the principle. If a principle itself needs to change, that must occur in a separate, explicit constitution update outside `/speckit.analyze`.
+
+## Execution Steps
+
+### 1. Initialize Analysis Context
+
+Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+
+- SPEC = FEATURE_DIR/spec.md
+- PLAN = FEATURE_DIR/plan.md
+- TASKS = FEATURE_DIR/tasks.md
+
+Abort with an error message if any required file is missing (instruct the user to run missing prerequisite command).
+For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+### 2. Load Artifacts (Progressive Disclosure)
+
+Load only the minimal necessary context from each artifact:
+
+**From spec.md:**
+
+- Overview/Context
+- Functional Requirements
+- Success Criteria (measurable outcomes — e.g., performance, security, availability, user success, business impact)
+- User Stories
+- Edge Cases (if present)
+
+**From plan.md:**
+
+- Architecture/stack choices
+- Data Model references
+- Phases
+- Technical constraints
+
+**From tasks.md:**
+
+- Task IDs
+- Descriptions
+- Phase grouping
+- Parallel markers [P]
+- Referenced file paths
+
+**From constitution:**
+
+- Load `.specify/memory/constitution.md` for principle validation
+
+### 3. Build Semantic Models
+
+Create internal representations (do not include raw artifacts in output):
+
+- **Requirements inventory**: For each Functional Requirement (FR-###) and Success Criterion (SC-###), record a stable key. Use the explicit FR-/SC- identifier as the primary key when present, and optionally also derive an imperative-phrase slug for readability (e.g., "User can upload file" → `user-can-upload-file`). Include only Success Criteria items that require buildable work (e.g., load-testing infrastructure, security audit tooling), and exclude post-launch outcome metrics and business KPIs (e.g., "Reduce support tickets by 50%").
+- **User story/action inventory**: Discrete user actions with acceptance criteria
+- **Task coverage mapping**: Map each task to one or more requirements or stories (inference by keyword / explicit reference patterns like IDs or key phrases)
+- **Constitution rule set**: Extract principle names and MUST/SHOULD normative statements
+
+### 4. Detection Passes (Token-Efficient Analysis)
+
+Focus on high-signal findings. Limit to 50 findings total; aggregate remainder in overflow summary.
+
+#### A. Duplication Detection
+
+- Identify near-duplicate requirements
+- Mark lower-quality phrasing for consolidation
+
+#### B. Ambiguity Detection
+
+- Flag vague adjectives (fast, scalable, secure, intuitive, robust) lacking measurable criteria
+- Flag unresolved placeholders (TODO, TKTK, ???, `<placeholder>`, etc.)
+
+#### C. Underspecification
+
+- Requirements with verbs but missing object or measurable outcome
+- User stories missing acceptance criteria alignment
+- Tasks referencing files or components not defined in spec/plan
+
+#### D. Constitution Alignment
+
+- Any requirement or plan element conflicting with a MUST principle
+- Missing mandated sections or quality gates from constitution
+
+#### E. Coverage Gaps
+
+- Requirements with zero associated tasks
+- Tasks with no mapped requirement/story
+- Success Criteria requiring buildable work (performance, security, availability) not reflected in tasks
+
+#### F. Inconsistency
+
+- Terminology drift (same concept named differently across files)
+- Data entities referenced in plan but absent in spec (or vice versa)
+- Task ordering contradictions (e.g., integration tasks before foundational setup tasks without dependency note)
+- Conflicting requirements (e.g., one requires Next.js while other specifies Vue)
+
+### 5. Severity Assignment
+
+Use this heuristic to prioritize findings:
+
+- **CRITICAL**: Violates constitution MUST, missing core spec artifact, or requirement with zero coverage that blocks baseline functionality
+- **HIGH**: Duplicate or conflicting requirement, ambiguous security/performance attribute, untestable acceptance criterion
+- **MEDIUM**: Terminology drift, missing non-functional task coverage, underspecified edge case
+- **LOW**: Style/wording improvements, minor redundancy not affecting execution order
+
+### 6. Produce Compact Analysis Report
+
+Output a Markdown report (no file writes) with the following structure:
+
+## Specification Analysis Report
+
+| ID | Category | Severity | Location(s) | Summary | Recommendation |
+|----|----------|----------|-------------|---------|----------------|
+| A1 | Duplication | HIGH | spec.md:L120-134 | Two similar requirements ... | Merge phrasing; keep clearer version |
+
+(Add one row per finding; generate stable IDs prefixed by category initial.)
+
+**Coverage Summary Table:**
+
+| Requirement Key | Has Task? | Task IDs | Notes |
+|-----------------|-----------|----------|-------|
+
+**Constitution Alignment Issues:** (if any)
+
+**Unmapped Tasks:** (if any)
+
+**Metrics:**
+
+- Total Requirements
+- Total Tasks
+- Coverage % (requirements with >=1 task)
+- Ambiguity Count
+- Duplication Count
+- Critical Issues Count
+
+### 7. Provide Next Actions
+
+At end of report, output a concise Next Actions block:
+
+- If CRITICAL issues exist: Recommend resolving before `/speckit.implement`
+- If only LOW/MEDIUM: User may proceed, but provide improvement suggestions
+- Provide explicit command suggestions: e.g., "Run /speckit.specify with refinement", "Run /speckit.plan to adjust architecture", "Manually edit tasks.md to add coverage for 'performance-metrics'"
+
+### 8. Offer Remediation
+
+Ask the user: "Would you like me to suggest concrete remediation edits for the top N issues?" (Do NOT apply them automatically.)
+
+### 9. Check for extension hooks
+
+After reporting, check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_analyze` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Operating Principles
+
+### Context Efficiency
+
+- **Minimal high-signal tokens**: Focus on actionable findings, not exhaustive documentation
+- **Progressive disclosure**: Load artifacts incrementally; don't dump all content into analysis
+- **Token-efficient output**: Limit findings table to 50 rows; summarize overflow
+- **Deterministic results**: Rerunning without changes should produce consistent IDs and counts
+
+### Analysis Guidelines
+
+- **NEVER modify files** (this is read-only analysis)
+- **NEVER hallucinate missing sections** (if absent, report them accurately)
+- **Prioritize constitution violations** (these are always CRITICAL)
+- **Use examples over exhaustive rules** (cite specific instances, not generic patterns)
+- **Report zero issues gracefully** (emit success report with coverage statistics)
+
+## Context
+
+$ARGUMENTS

--- a/.opencode/command/speckit.checklist.md
+++ b/.opencode/command/speckit.checklist.md
@@ -1,0 +1,361 @@
+---
+description: Generate a custom checklist for the current feature based on user requirements.
+---
+
+## Checklist Purpose: "Unit Tests for English"
+
+**CRITICAL CONCEPT**: Checklists are **UNIT TESTS FOR REQUIREMENTS WRITING** - they validate the quality, clarity, and completeness of requirements in a given domain.
+
+**NOT for verification/testing**:
+
+- ❌ NOT "Verify the button clicks correctly"
+- ❌ NOT "Test error handling works"
+- ❌ NOT "Confirm the API returns 200"
+- ❌ NOT checking if code/implementation matches the spec
+
+**FOR requirements quality validation**:
+
+- ✅ "Are visual hierarchy requirements defined for all card types?" (completeness)
+- ✅ "Is 'prominent display' quantified with specific sizing/positioning?" (clarity)
+- ✅ "Are hover state requirements consistent across all interactive elements?" (consistency)
+- ✅ "Are accessibility requirements defined for keyboard navigation?" (coverage)
+- ✅ "Does the spec define what happens when logo image fails to load?" (edge cases)
+
+**Metaphor**: If your spec is code written in English, the checklist is its unit test suite. You're testing whether the requirements are well-written, complete, unambiguous, and ready for implementation - NOT whether the implementation works.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before checklist generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Execution Steps.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Execution Steps
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS list.
+   - All file paths must be absolute.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Clarify intent (dynamic)**: Derive up to THREE initial contextual clarifying questions (no pre-baked catalog). They MUST:
+   - Be generated from the user's phrasing + extracted signals from spec/plan/tasks
+   - Only ask about information that materially changes checklist content
+   - Be skipped individually if already unambiguous in `$ARGUMENTS`
+   - Prefer precision over breadth
+
+   Generation algorithm:
+   1. Extract signals: feature domain keywords (e.g., auth, latency, UX, API), risk indicators ("critical", "must", "compliance"), stakeholder hints ("QA", "review", "security team"), and explicit deliverables ("a11y", "rollback", "contracts").
+   2. Cluster signals into candidate focus areas (max 4) ranked by relevance.
+   3. Identify probable audience & timing (author, reviewer, QA, release) if not explicit.
+   4. Detect missing dimensions: scope breadth, depth/rigor, risk emphasis, exclusion boundaries, measurable acceptance criteria.
+   5. Formulate questions chosen from these archetypes:
+      - Scope refinement (e.g., "Should this include integration touchpoints with X and Y or stay limited to local module correctness?")
+      - Risk prioritization (e.g., "Which of these potential risk areas should receive mandatory gating checks?")
+      - Depth calibration (e.g., "Is this a lightweight pre-commit sanity list or a formal release gate?")
+      - Audience framing (e.g., "Will this be used by the author only or peers during PR review?")
+      - Boundary exclusion (e.g., "Should we explicitly exclude performance tuning items this round?")
+      - Scenario class gap (e.g., "No recovery flows detected—are rollback / partial failure paths in scope?")
+
+   Question formatting rules:
+   - If presenting options, generate a compact table with columns: Option | Candidate | Why It Matters
+   - Limit to A–E options maximum; omit table if a free-form answer is clearer
+   - Never ask the user to restate what they already said
+   - Avoid speculative categories (no hallucination). If uncertain, ask explicitly: "Confirm whether X belongs in scope."
+
+   Defaults when interaction impossible:
+   - Depth: Standard
+   - Audience: Reviewer (PR) if code-related; Author otherwise
+   - Focus: Top 2 relevance clusters
+
+   Output the questions (label Q1/Q2/Q3). After answers: if ≥2 scenario classes (Alternate / Exception / Recovery / Non-Functional domain) remain unclear, you MAY ask up to TWO more targeted follow‑ups (Q4/Q5) with a one-line justification each (e.g., "Unresolved recovery path risk"). Do not exceed five total questions. Skip escalation if user explicitly declines more.
+
+3. **Understand user request**: Combine `$ARGUMENTS` + clarifying answers:
+   - Derive checklist theme (e.g., security, review, deploy, ux)
+   - Consolidate explicit must-have items mentioned by user
+   - Map focus selections to category scaffolding
+   - Infer any missing context from spec/plan/tasks (do NOT hallucinate)
+
+4. **Load feature context**: Read from FEATURE_DIR:
+   - spec.md: Feature requirements and scope
+   - plan.md (if exists): Technical details, dependencies
+   - tasks.md (if exists): Implementation tasks
+
+   **Context Loading Strategy**:
+   - Load only necessary portions relevant to active focus areas (avoid full-file dumping)
+   - Prefer summarizing long sections into concise scenario/requirement bullets
+   - Use progressive disclosure: add follow-on retrieval only if gaps detected
+   - If source docs are large, generate interim summary items instead of embedding raw text
+
+5. **Generate checklist** - Create "Unit Tests for Requirements":
+   - Create `FEATURE_DIR/checklists/` directory if it doesn't exist
+   - Generate unique checklist filename:
+     - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
+     - Format: `[domain].md`
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
+
+   **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
+   Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
+   - **Completeness**: Are all necessary requirements present?
+   - **Clarity**: Are requirements unambiguous and specific?
+   - **Consistency**: Do requirements align with each other?
+   - **Measurability**: Can requirements be objectively verified?
+   - **Coverage**: Are all scenarios/edge cases addressed?
+
+   **Category Structure** - Group items by requirement quality dimensions:
+   - **Requirement Completeness** (Are all necessary requirements documented?)
+   - **Requirement Clarity** (Are requirements specific and unambiguous?)
+   - **Requirement Consistency** (Do requirements align without conflicts?)
+   - **Acceptance Criteria Quality** (Are success criteria measurable?)
+   - **Scenario Coverage** (Are all flows/cases addressed?)
+   - **Edge Case Coverage** (Are boundary conditions defined?)
+   - **Non-Functional Requirements** (Performance, Security, Accessibility, etc. - are they specified?)
+   - **Dependencies & Assumptions** (Are they documented and validated?)
+   - **Ambiguities & Conflicts** (What needs clarification?)
+
+   **HOW TO WRITE CHECKLIST ITEMS - "Unit Tests for English"**:
+
+   ❌ **WRONG** (Testing implementation):
+   - "Verify landing page displays 3 episode cards"
+   - "Test hover states work on desktop"
+   - "Confirm logo click navigates home"
+
+   ✅ **CORRECT** (Testing requirements quality):
+   - "Are the exact number and layout of featured episodes specified?" [Completeness]
+   - "Is 'prominent display' quantified with specific sizing/positioning?" [Clarity]
+   - "Are hover state requirements consistent across all interactive elements?" [Consistency]
+   - "Are keyboard navigation requirements defined for all interactive UI?" [Coverage]
+   - "Is the fallback behavior specified when logo image fails to load?" [Edge Cases]
+   - "Are loading states defined for asynchronous episode data?" [Completeness]
+   - "Does the spec define visual hierarchy for competing UI elements?" [Clarity]
+
+   **ITEM STRUCTURE**:
+   Each item should follow this pattern:
+   - Question format asking about requirement quality
+   - Focus on what's WRITTEN (or not written) in the spec/plan
+   - Include quality dimension in brackets [Completeness/Clarity/Consistency/etc.]
+   - Reference spec section `[Spec §X.Y]` when checking existing requirements
+   - Use `[Gap]` marker when checking for missing requirements
+
+   **EXAMPLES BY QUALITY DIMENSION**:
+
+   Completeness:
+   - "Are error handling requirements defined for all API failure modes? [Gap]"
+   - "Are accessibility requirements specified for all interactive elements? [Completeness]"
+   - "Are mobile breakpoint requirements defined for responsive layouts? [Gap]"
+
+   Clarity:
+   - "Is 'fast loading' quantified with specific timing thresholds? [Clarity, Spec §NFR-2]"
+   - "Are 'related episodes' selection criteria explicitly defined? [Clarity, Spec §FR-5]"
+   - "Is 'prominent' defined with measurable visual properties? [Ambiguity, Spec §FR-4]"
+
+   Consistency:
+   - "Do navigation requirements align across all pages? [Consistency, Spec §FR-10]"
+   - "Are card component requirements consistent between landing and detail pages? [Consistency]"
+
+   Coverage:
+   - "Are requirements defined for zero-state scenarios (no episodes)? [Coverage, Edge Case]"
+   - "Are concurrent user interaction scenarios addressed? [Coverage, Gap]"
+   - "Are requirements specified for partial data loading failures? [Coverage, Exception Flow]"
+
+   Measurability:
+   - "Are visual hierarchy requirements measurable/testable? [Acceptance Criteria, Spec §FR-1]"
+   - "Can 'balanced visual weight' be objectively verified? [Measurability, Spec §FR-2]"
+
+   **Scenario Classification & Coverage** (Requirements Quality Focus):
+   - Check if requirements exist for: Primary, Alternate, Exception/Error, Recovery, Non-Functional scenarios
+   - For each scenario class, ask: "Are [scenario type] requirements complete, clear, and consistent?"
+   - If scenario class missing: "Are [scenario type] requirements intentionally excluded or missing? [Gap]"
+   - Include resilience/rollback when state mutation occurs: "Are rollback requirements defined for migration failures? [Gap]"
+
+   **Traceability Requirements**:
+   - MINIMUM: ≥80% of items MUST include at least one traceability reference
+   - Each item should reference: spec section `[Spec §X.Y]`, or use markers: `[Gap]`, `[Ambiguity]`, `[Conflict]`, `[Assumption]`
+   - If no ID system exists: "Is a requirement & acceptance criteria ID scheme established? [Traceability]"
+
+   **Surface & Resolve Issues** (Requirements Quality Problems):
+   Ask questions about the requirements themselves:
+   - Ambiguities: "Is the term 'fast' quantified with specific metrics? [Ambiguity, Spec §NFR-1]"
+   - Conflicts: "Do navigation requirements conflict between §FR-10 and §FR-10a? [Conflict]"
+   - Assumptions: "Is the assumption of 'always available podcast API' validated? [Assumption]"
+   - Dependencies: "Are external podcast API requirements documented? [Dependency, Gap]"
+   - Missing definitions: "Is 'visual hierarchy' defined with measurable criteria? [Gap]"
+
+   **Content Consolidation**:
+   - Soft cap: If raw candidate items > 40, prioritize by risk/impact
+   - Merge near-duplicates checking the same requirement aspect
+   - If >5 low-impact edge cases, create one item: "Are edge cases X, Y, Z addressed in requirements? [Coverage]"
+
+   **🚫 ABSOLUTELY PROHIBITED** - These make it an implementation test, not a requirements test:
+   - ❌ Any item starting with "Verify", "Test", "Confirm", "Check" + implementation behavior
+   - ❌ References to code execution, user actions, system behavior
+   - ❌ "Displays correctly", "works properly", "functions as expected"
+   - ❌ "Click", "navigate", "render", "load", "execute"
+   - ❌ Test cases, test plans, QA procedures
+   - ❌ Implementation details (frameworks, APIs, algorithms)
+
+   **✅ REQUIRED PATTERNS** - These test requirements quality:
+   - ✅ "Are [requirement type] defined/specified/documented for [scenario]?"
+   - ✅ "Is [vague term] quantified/clarified with specific criteria?"
+   - ✅ "Are requirements consistent between [section A] and [section B]?"
+   - ✅ "Can [requirement] be objectively measured/verified?"
+   - ✅ "Are [edge cases/scenarios] addressed in requirements?"
+   - ✅ "Does the spec define [missing aspect]?"
+
+6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
+
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
+   - Focus areas selected
+   - Depth level
+   - Actor/timing
+   - Any explicit user-specified must-have items incorporated
+
+**Important**: Each `/speckit.checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
+
+- Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
+- Simple, memorable filenames that indicate checklist purpose
+- Easy identification and navigation in the `checklists/` folder
+
+To avoid clutter, use descriptive types and clean up obsolete checklists when done.
+
+## Example Checklist Types & Sample Items
+
+**UX Requirements Quality:** `ux.md`
+
+Sample items (testing the requirements, NOT the implementation):
+
+- "Are visual hierarchy requirements defined with measurable criteria? [Clarity, Spec §FR-1]"
+- "Is the number and positioning of UI elements explicitly specified? [Completeness, Spec §FR-1]"
+- "Are interaction state requirements (hover, focus, active) consistently defined? [Consistency]"
+- "Are accessibility requirements specified for all interactive elements? [Coverage, Gap]"
+- "Is fallback behavior defined when images fail to load? [Edge Case, Gap]"
+- "Can 'prominent display' be objectively measured? [Measurability, Spec §FR-4]"
+
+**API Requirements Quality:** `api.md`
+
+Sample items:
+
+- "Are error response formats specified for all failure scenarios? [Completeness]"
+- "Are rate limiting requirements quantified with specific thresholds? [Clarity]"
+- "Are authentication requirements consistent across all endpoints? [Consistency]"
+- "Are retry/timeout requirements defined for external dependencies? [Coverage, Gap]"
+- "Is versioning strategy documented in requirements? [Gap]"
+
+**Performance Requirements Quality:** `performance.md`
+
+Sample items:
+
+- "Are performance requirements quantified with specific metrics? [Clarity]"
+- "Are performance targets defined for all critical user journeys? [Coverage]"
+- "Are performance requirements under different load conditions specified? [Completeness]"
+- "Can performance requirements be objectively measured? [Measurability]"
+- "Are degradation requirements defined for high-load scenarios? [Edge Case, Gap]"
+
+**Security Requirements Quality:** `security.md`
+
+Sample items:
+
+- "Are authentication requirements specified for all protected resources? [Coverage]"
+- "Are data protection requirements defined for sensitive information? [Completeness]"
+- "Is the threat model documented and requirements aligned to it? [Traceability]"
+- "Are security requirements consistent with compliance obligations? [Consistency]"
+- "Are security failure/breach response requirements defined? [Gap, Exception Flow]"
+
+## Anti-Examples: What NOT To Do
+
+**❌ WRONG - These test implementation, not requirements:**
+
+```markdown
+- [ ] CHK001 - Verify landing page displays 3 episode cards [Spec §FR-001]
+- [ ] CHK002 - Test hover states work correctly on desktop [Spec §FR-003]
+- [ ] CHK003 - Confirm logo click navigates to home page [Spec §FR-010]
+- [ ] CHK004 - Check that related episodes section shows 3-5 items [Spec §FR-005]
+```
+
+**✅ CORRECT - These test requirements quality:**
+
+```markdown
+- [ ] CHK001 - Are the number and layout of featured episodes explicitly specified? [Completeness, Spec §FR-001]
+- [ ] CHK002 - Are hover state requirements consistently defined for all interactive elements? [Consistency, Spec §FR-003]
+- [ ] CHK003 - Are navigation requirements clear for all clickable brand elements? [Clarity, Spec §FR-010]
+- [ ] CHK004 - Is the selection criteria for related episodes documented? [Gap, Spec §FR-005]
+- [ ] CHK005 - Are loading state requirements defined for asynchronous episode data? [Gap]
+- [ ] CHK006 - Can "visual hierarchy" requirements be objectively measured? [Measurability, Spec §FR-001]
+```
+
+**Key Differences:**
+
+- Wrong: Tests if the system works correctly
+- Correct: Tests if the requirements are written correctly
+- Wrong: Verification of behavior
+- Correct: Validation of requirement quality
+- Wrong: "Does it do X?"
+- Correct: "Is X clearly specified?"
+
+## Post-Execution Checks
+
+**Check for extension hooks (after checklist generation)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_checklist` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.opencode/command/speckit.clarify.md
+++ b/.opencode/command/speckit.clarify.md
@@ -1,0 +1,247 @@
+---
+description: Identify underspecified areas in the current feature spec by asking up to 5 highly targeted clarification questions and encoding answers back into the spec.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before clarification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+Goal: Detect and reduce ambiguity or missing decision points in the active feature specification and record the clarifications directly in the spec file.
+
+Note: This clarification workflow is expected to run (and be completed) BEFORE invoking `/speckit.plan`. If the user explicitly states they are skipping clarification (e.g., exploratory spike), you may proceed, but must warn that downstream rework risk increases.
+
+Execution steps:
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -PathsOnly` from repo root **once** (combined `--json --paths-only` mode / `-Json -PathsOnly`). Parse minimal JSON payload fields:
+   - `FEATURE_DIR`
+   - `FEATURE_SPEC`
+   - (Optionally capture `IMPL_PLAN`, `TASKS` for future chained flows.)
+   - If JSON parsing fails, abort and instruct user to re-run `/speckit.specify` or verify feature branch environment.
+   - For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. Load the current spec file. Perform a structured ambiguity & coverage scan using this taxonomy. For each category, mark status: Clear / Partial / Missing. Produce an internal coverage map used for prioritization (do not output raw map unless no questions will be asked).
+
+   Functional Scope & Behavior:
+   - Core user goals & success criteria
+   - Explicit out-of-scope declarations
+   - User roles / personas differentiation
+
+   Domain & Data Model:
+   - Entities, attributes, relationships
+   - Identity & uniqueness rules
+   - Lifecycle/state transitions
+   - Data volume / scale assumptions
+
+   Interaction & UX Flow:
+   - Critical user journeys / sequences
+   - Error/empty/loading states
+   - Accessibility or localization notes
+
+   Non-Functional Quality Attributes:
+   - Performance (latency, throughput targets)
+   - Scalability (horizontal/vertical, limits)
+   - Reliability & availability (uptime, recovery expectations)
+   - Observability (logging, metrics, tracing signals)
+   - Security & privacy (authN/Z, data protection, threat assumptions)
+   - Compliance / regulatory constraints (if any)
+
+   Integration & External Dependencies:
+   - External services/APIs and failure modes
+   - Data import/export formats
+   - Protocol/versioning assumptions
+
+   Edge Cases & Failure Handling:
+   - Negative scenarios
+   - Rate limiting / throttling
+   - Conflict resolution (e.g., concurrent edits)
+
+   Constraints & Tradeoffs:
+   - Technical constraints (language, storage, hosting)
+   - Explicit tradeoffs or rejected alternatives
+
+   Terminology & Consistency:
+   - Canonical glossary terms
+   - Avoided synonyms / deprecated terms
+
+   Completion Signals:
+   - Acceptance criteria testability
+   - Measurable Definition of Done style indicators
+
+   Misc / Placeholders:
+   - TODO markers / unresolved decisions
+   - Ambiguous adjectives ("robust", "intuitive") lacking quantification
+
+   For each category with Partial or Missing status, add a candidate question opportunity unless:
+   - Clarification would not materially change implementation or validation strategy
+   - Information is better deferred to planning phase (note internally)
+
+3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
+    - Maximum of 5 total questions across the whole session.
+    - Each question must be answerable with EITHER:
+       - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
+       - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").
+    - Only include questions whose answers materially impact architecture, data modeling, task decomposition, test design, UX behavior, operational readiness, or compliance validation.
+    - Ensure category coverage balance: attempt to cover the highest impact unresolved categories first; avoid asking two low-impact questions when a single high-impact area (e.g., security posture) is unresolved.
+    - Exclude questions already answered, trivial stylistic preferences, or plan-level execution details (unless blocking correctness).
+    - Favor clarifications that reduce downstream rework risk or prevent misaligned acceptance tests.
+    - If more than 5 categories remain unresolved, select the top 5 by (Impact * Uncertainty) heuristic.
+
+4. Sequential questioning loop (interactive):
+    - Present EXACTLY ONE question at a time.
+    - For multiple‑choice questions:
+       - **Analyze all options** and determine the **most suitable option** based on:
+          - Best practices for the project type
+          - Common patterns in similar implementations
+          - Risk reduction (security, performance, maintainability)
+          - Alignment with any explicit project goals or constraints visible in the spec
+       - Present your **recommended option prominently** at the top with clear reasoning (1-2 sentences explaining why this is the best choice).
+       - Format as: `**Recommended:** Option [X] - <reasoning>`
+       - Then render all options as a Markdown table:
+
+       | Option | Description |
+       |--------|-------------|
+       | A | <Option A description> |
+       | B | <Option B description> |
+       | C | <Option C description> (add D/E as needed up to 5) |
+       | Short | Provide a different short answer (<=5 words) (Include only if free-form alternative is appropriate) |
+
+       - After the table, add: `You can reply with the option letter (e.g., "A"), accept the recommendation by saying "yes" or "recommended", or provide your own short answer.`
+    - For short‑answer style (no meaningful discrete options):
+       - Provide your **suggested answer** based on best practices and context.
+       - Format as: `**Suggested:** <your proposed answer> - <brief reasoning>`
+       - Then output: `Format: Short answer (<=5 words). You can accept the suggestion by saying "yes" or "suggested", or provide your own answer.`
+    - After the user answers:
+       - If the user replies with "yes", "recommended", or "suggested", use your previously stated recommendation/suggestion as the answer.
+       - Otherwise, validate the answer maps to one option or fits the <=5 word constraint.
+       - If ambiguous, ask for a quick disambiguation (count still belongs to same question; do not advance).
+       - Once satisfactory, record it in working memory (do not yet write to disk) and move to the next queued question.
+    - Stop asking further questions when:
+       - All critical ambiguities resolved early (remaining queued items become unnecessary), OR
+       - User signals completion ("done", "good", "no more"), OR
+       - You reach 5 asked questions.
+    - Never reveal future queued questions in advance.
+    - If no valid questions exist at start, immediately report no critical ambiguities.
+
+5. Integration after EACH accepted answer (incremental update approach):
+    - Maintain in-memory representation of the spec (loaded once at start) plus the raw file contents.
+    - For the first integrated answer in this session:
+       - Ensure a `## Clarifications` section exists (create it just after the highest-level contextual/overview section per the spec template if missing).
+       - Under it, create (if not present) a `### Session YYYY-MM-DD` subheading for today.
+    - Append a bullet line immediately after acceptance: `- Q: <question> → A: <final answer>`.
+    - Then immediately apply the clarification to the most appropriate section(s):
+       - Functional ambiguity → Update or add a bullet in Functional Requirements.
+       - User interaction / actor distinction → Update User Stories or Actors subsection (if present) with clarified role, constraint, or scenario.
+       - Data shape / entities → Update Data Model (add fields, types, relationships) preserving ordering; note added constraints succinctly.
+       - Non-functional constraint → Add/modify measurable criteria in Success Criteria > Measurable Outcomes (convert vague adjective to metric or explicit target).
+       - Edge case / negative flow → Add a new bullet under Edge Cases / Error Handling (or create such subsection if template provides placeholder for it).
+       - Terminology conflict → Normalize term across spec; retain original only if necessary by adding `(formerly referred to as "X")` once.
+    - If the clarification invalidates an earlier ambiguous statement, replace that statement instead of duplicating; leave no obsolete contradictory text.
+    - Save the spec file AFTER each integration to minimize risk of context loss (atomic overwrite).
+    - Preserve formatting: do not reorder unrelated sections; keep heading hierarchy intact.
+    - Keep each inserted clarification minimal and testable (avoid narrative drift).
+
+6. Validation (performed after EACH write plus final pass):
+   - Clarifications session contains exactly one bullet per accepted answer (no duplicates).
+   - Total asked (accepted) questions ≤ 5.
+   - Updated sections contain no lingering vague placeholders the new answer was meant to resolve.
+   - No contradictory earlier statement remains (scan for now-invalid alternative choices removed).
+   - Markdown structure valid; only allowed new headings: `## Clarifications`, `### Session YYYY-MM-DD`.
+   - Terminology consistency: same canonical term used across all updated sections.
+
+7. Write the updated spec back to `FEATURE_SPEC`.
+
+8. Report completion (after questioning loop ends or early termination):
+   - Number of questions asked & answered.
+   - Path to updated spec.
+   - Sections touched (list names).
+   - Coverage summary table listing each taxonomy category with Status: Resolved (was Partial/Missing and addressed), Deferred (exceeds question quota or better suited for planning), Clear (already sufficient), Outstanding (still Partial/Missing but low impact).
+   - If any Outstanding or Deferred remain, recommend whether to proceed to `/speckit.plan` or run `/speckit.clarify` again later post-plan.
+   - Suggested next command.
+
+Behavior rules:
+
+- If no meaningful ambiguities found (or all potential questions would be low-impact), respond: "No critical ambiguities detected worth formal clarification." and suggest proceeding.
+- If spec file missing, instruct user to run `/speckit.specify` first (do not create a new spec here).
+- Never exceed 5 total asked questions (clarification retries for a single question do not count as new questions).
+- Avoid speculative tech stack questions unless the absence blocks functional clarity.
+- Respect user early termination signals ("stop", "done", "proceed").
+- If no questions asked due to full coverage, output a compact coverage summary (all categories Clear) then suggest advancing.
+- If quota reached with unresolved high-impact categories remaining, explicitly flag them under Deferred with rationale.
+
+Context for prioritization: $ARGUMENTS
+
+## Post-Execution Checks
+
+**Check for extension hooks (after clarification)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_clarify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.opencode/command/speckit.constitution.md
+++ b/.opencode/command/speckit.constitution.md
@@ -1,0 +1,150 @@
+---
+description: Create or update the project constitution from interactive or provided principle inputs, ensuring all dependent templates stay in sync.
+handoffs: 
+  - label: Build Specification
+    agent: speckit.specify
+    prompt: Implement the feature specification based on the updated constitution. I want to build...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before constitution update)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
+
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
+Follow this execution flow:
+
+1. Load the existing constitution at `.specify/memory/constitution.md`.
+   - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
+   **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
+
+2. Collect/derive values for placeholders:
+   - If user input (conversation) supplies a value, use it.
+   - Otherwise infer from existing repo context (README, docs, prior constitution versions if embedded).
+   - For governance dates: `RATIFICATION_DATE` is the original adoption date (if unknown ask or mark TODO), `LAST_AMENDED_DATE` is today if changes are made, otherwise keep previous.
+   - `CONSTITUTION_VERSION` must increment according to semantic versioning rules:
+     - MAJOR: Backward incompatible governance/principle removals or redefinitions.
+     - MINOR: New principle/section added or materially expanded guidance.
+     - PATCH: Clarifications, wording, typo fixes, non-semantic refinements.
+   - If version bump type ambiguous, propose reasoning before finalizing.
+
+3. Draft the updated constitution content:
+   - Replace every placeholder with concrete text (no bracketed tokens left except intentionally retained template slots that the project has chosen not to define yet—explicitly justify any left).
+   - Preserve heading hierarchy and comments can be removed once replaced unless they still add clarifying guidance.
+   - Ensure each Principle section: succinct name line, paragraph (or bullet list) capturing non‑negotiable rules, explicit rationale if not obvious.
+   - Ensure Governance section lists amendment procedure, versioning policy, and compliance review expectations.
+
+4. Consistency propagation checklist (convert prior checklist into active validations):
+   - Read `.specify/templates/plan-template.md` and ensure any "Constitution Check" or rules align with updated principles.
+   - Read `.specify/templates/spec-template.md` for scope/requirements alignment—update if constitution adds/removes mandatory sections or constraints.
+   - Read `.specify/templates/tasks-template.md` and ensure task categorization reflects new or removed principle-driven task types (e.g., observability, versioning, testing discipline).
+   - Read each command file in `.specify/templates/commands/*.md` (including this one) to verify no outdated references (agent-specific names like CLAUDE only) remain when generic guidance is required.
+   - Read any runtime guidance docs (e.g., `README.md`, `docs/quickstart.md`, or agent-specific guidance files if present). Update references to principles changed.
+
+5. Produce a Sync Impact Report (prepend as an HTML comment at top of the constitution file after update):
+   - Version change: old → new
+   - List of modified principles (old title → new title if renamed)
+   - Added sections
+   - Removed sections
+   - Templates requiring updates (✅ updated / ⚠ pending) with file paths
+   - Follow-up TODOs if any placeholders intentionally deferred.
+
+6. Validation before final output:
+   - No remaining unexplained bracket tokens.
+   - Version line matches report.
+   - Dates ISO format YYYY-MM-DD.
+   - Principles are declarative, testable, and free of vague language ("should" → replace with MUST/SHOULD rationale where appropriate).
+
+7. Write the completed constitution back to `.specify/memory/constitution.md` (overwrite).
+
+8. Output a final summary to the user with:
+   - New version and bump rationale.
+   - Any files flagged for manual follow-up.
+   - Suggested commit message (e.g., `docs: amend constitution to vX.Y.Z (principle additions + governance update)`).
+
+Formatting & Style Requirements:
+
+- Use Markdown headings exactly as in the template (do not demote/promote levels).
+- Wrap long rationale lines to keep readability (<100 chars ideally) but do not hard enforce with awkward breaks.
+- Keep a single blank line between sections.
+- Avoid trailing whitespace.
+
+If the user supplies partial updates (e.g., only one principle revision), still perform validation and version decision steps.
+
+If critical info missing (e.g., ratification date truly unknown), insert `TODO(<FIELD_NAME>): explanation` and include in the Sync Impact Report under deferred items.
+
+Do not create a new template; always operate on the existing `.specify/memory/constitution.md` file.
+
+## Post-Execution Checks
+
+**Check for extension hooks (after constitution update)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_constitution` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.opencode/command/speckit.implement.md
+++ b/.opencode/command/speckit.implement.md
@@ -1,0 +1,198 @@
+---
+description: Execute the implementation plan by processing and executing all tasks defined in tasks.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Check checklists status** (if FEATURE_DIR/checklists/ exists):
+   - Scan all checklist files in the checklists/ directory
+   - For each checklist, count:
+     - Total items: All lines matching `- [ ]` or `- [X]` or `- [x]`
+     - Completed items: Lines matching `- [X]` or `- [x]`
+     - Incomplete items: Lines matching `- [ ]`
+   - Create a status table:
+
+     ```text
+     | Checklist | Total | Completed | Incomplete | Status |
+     |-----------|-------|-----------|------------|--------|
+     | ux.md     | 12    | 12        | 0          | ✓ PASS |
+     | test.md   | 8     | 5         | 3          | ✗ FAIL |
+     | security.md | 6   | 6         | 0          | ✓ PASS |
+     ```
+
+   - Calculate overall status:
+     - **PASS**: All checklists have 0 incomplete items
+     - **FAIL**: One or more checklists have incomplete items
+
+   - **If any checklist is incomplete**:
+     - Display the table with incomplete item counts
+     - **STOP** and ask: "Some checklists are incomplete. Do you want to proceed with implementation anyway? (yes/no)"
+     - Wait for user response before continuing
+     - If user says "no" or "wait" or "stop", halt execution
+     - If user says "yes" or "proceed" or "continue", proceed to step 3
+
+   - **If all checklists are complete**:
+     - Display the table showing all checklists passed
+     - Automatically proceed to step 3
+
+3. Load and analyze the implementation context:
+   - **REQUIRED**: Read tasks.md for the complete task list and execution plan
+   - **REQUIRED**: Read plan.md for tech stack, architecture, and file structure
+   - **IF EXISTS**: Read data-model.md for entities and relationships
+   - **IF EXISTS**: Read contracts/ for API specifications and test requirements
+   - **IF EXISTS**: Read research.md for technical decisions and constraints
+   - **IF EXISTS**: Read quickstart.md for integration scenarios
+
+4. **Project Setup Verification**:
+   - **REQUIRED**: Create/verify ignore files based on actual project setup:
+
+   **Detection & Creation Logic**:
+   - Check if the following command succeeds to determine if the repository is a git repo (create/verify .gitignore if so):
+
+     ```sh
+     git rev-parse --git-dir 2>/dev/null
+     ```
+
+   - Check if Dockerfile* exists or Docker in plan.md → create/verify .dockerignore
+   - Check if .eslintrc* exists → create/verify .eslintignore
+   - Check if eslint.config.* exists → ensure the config's `ignores` entries cover required patterns
+   - Check if .prettierrc* exists → create/verify .prettierignore
+   - Check if .npmrc or package.json exists → create/verify .npmignore (if publishing)
+   - Check if terraform files (*.tf) exist → create/verify .terraformignore
+   - Check if .helmignore needed (helm charts present) → create/verify .helmignore
+
+   **If ignore file already exists**: Verify it contains essential patterns, append missing critical patterns only
+   **If ignore file missing**: Create with full pattern set for detected technology
+
+   **Common Patterns by Technology** (from plan.md tech stack):
+   - **Node.js/JavaScript/TypeScript**: `node_modules/`, `dist/`, `build/`, `*.log`, `.env*`
+   - **Python**: `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `dist/`, `*.egg-info/`
+   - **Java**: `target/`, `*.class`, `*.jar`, `.gradle/`, `build/`
+   - **C#/.NET**: `bin/`, `obj/`, `*.user`, `*.suo`, `packages/`
+   - **Go**: `*.exe`, `*.test`, `vendor/`, `*.out`
+   - **Ruby**: `.bundle/`, `log/`, `tmp/`, `*.gem`, `vendor/bundle/`
+   - **PHP**: `vendor/`, `*.log`, `*.cache`, `*.env`
+   - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
+   - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
+   - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
+   - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
+   - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
+
+   **Tool-Specific Patterns**:
+   - **Docker**: `node_modules/`, `.git/`, `Dockerfile*`, `.dockerignore`, `*.log*`, `.env*`, `coverage/`
+   - **ESLint**: `node_modules/`, `dist/`, `build/`, `coverage/`, `*.min.js`
+   - **Prettier**: `node_modules/`, `dist/`, `build/`, `coverage/`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`
+   - **Terraform**: `.terraform/`, `*.tfstate*`, `*.tfvars`, `.terraform.lock.hcl`
+   - **Kubernetes/k8s**: `*.secret.yaml`, `secrets/`, `.kube/`, `kubeconfig*`, `*.key`, `*.crt`
+
+5. Parse tasks.md structure and extract:
+   - **Task phases**: Setup, Tests, Core, Integration, Polish
+   - **Task dependencies**: Sequential vs parallel execution rules
+   - **Task details**: ID, description, file paths, parallel markers [P]
+   - **Execution flow**: Order and dependency requirements
+
+6. Execute implementation following the task plan:
+   - **Phase-by-phase execution**: Complete each phase before moving to the next
+   - **Respect dependencies**: Run sequential tasks in order, parallel tasks [P] can run together  
+   - **Follow TDD approach**: Execute test tasks before their corresponding implementation tasks
+   - **File-based coordination**: Tasks affecting the same files must run sequentially
+   - **Validation checkpoints**: Verify each phase completion before proceeding
+
+7. Implementation execution rules:
+   - **Setup first**: Initialize project structure, dependencies, configuration
+   - **Tests before code**: If you need to write tests for contracts, entities, and integration scenarios
+   - **Core development**: Implement models, services, CLI commands, endpoints
+   - **Integration work**: Database connections, middleware, logging, external services
+   - **Polish and validation**: Unit tests, performance optimization, documentation
+
+8. Progress tracking and error handling:
+   - Report progress after each completed task
+   - Halt execution if any non-parallel task fails
+   - For parallel tasks [P], continue with successful tasks, report failed ones
+   - Provide clear error messages with context for debugging
+   - Suggest next steps if implementation cannot proceed
+   - **IMPORTANT** For completed tasks, make sure to mark the task off as [X] in the tasks file.
+
+9. Completion validation:
+   - Verify all required tasks are completed
+   - Check that implemented features match the original specification
+   - Validate that tests pass and coverage meets requirements
+   - Confirm the implementation follows the technical plan
+   - Report final status with summary of completed work
+
+Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.opencode/command/speckit.plan.md
+++ b/.opencode/command/speckit.plan.md
@@ -1,0 +1,149 @@
+---
+description: Execute the implementation planning workflow using the plan template to generate design artifacts.
+handoffs: 
+  - label: Create Tasks
+    agent: speckit.tasks
+    prompt: Break the plan into tasks
+    send: true
+  - label: Create Checklist
+    agent: speckit.checklist
+    prompt: Create a checklist for the following domain...
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before planning)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_plan` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/setup-plan.ps1 -Json` from repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load context**: Read FEATURE_SPEC and `.specify/memory/constitution.md`. Load IMPL_PLAN template (already copied).
+
+3. **Execute plan workflow**: Follow the structure in IMPL_PLAN template to:
+   - Fill Technical Context (mark unknowns as "NEEDS CLARIFICATION")
+   - Fill Constitution Check section from constitution
+   - Evaluate gates (ERROR if violations unjustified)
+   - Phase 0: Generate research.md (resolve all NEEDS CLARIFICATION)
+   - Phase 1: Generate data-model.md, contracts/, quickstart.md
+   - Phase 1: Update agent context by running the agent script
+   - Re-evaluate Constitution Check post-design
+
+4. **Stop and report**: Command ends after Phase 2 planning. Report branch, IMPL_PLAN path, and generated artifacts.
+
+5. **Check for extension hooks**: After reporting, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_plan` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Phases
+
+### Phase 0: Outline & Research
+
+1. **Extract unknowns from Technical Context** above:
+   - For each NEEDS CLARIFICATION → research task
+   - For each dependency → best practices task
+   - For each integration → patterns task
+
+2. **Generate and dispatch research agents**:
+
+   ```text
+   For each unknown in Technical Context:
+     Task: "Research {unknown} for {feature context}"
+   For each technology choice:
+     Task: "Find best practices for {tech} in {domain}"
+   ```
+
+3. **Consolidate findings** in `research.md` using format:
+   - Decision: [what was chosen]
+   - Rationale: [why chosen]
+   - Alternatives considered: [what else evaluated]
+
+**Output**: research.md with all NEEDS CLARIFICATION resolved
+
+### Phase 1: Design & Contracts
+
+**Prerequisites:** `research.md` complete
+
+1. **Extract entities from feature spec** → `data-model.md`:
+   - Entity name, fields, relationships
+   - Validation rules from requirements
+   - State transitions if applicable
+
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
+
+3. **Agent context update**:
+   - Update the plan reference between the `<!-- SPECKIT START -->` and `<!-- SPECKIT END -->` markers in `AGENTS.md` to point to the plan file created in step 1 (the IMPL_PLAN path)
+
+**Output**: data-model.md, /contracts/*, quickstart.md, updated agent context file
+
+## Key rules
+
+- Use absolute paths for filesystem operations; use project-relative paths for references in documentation and agent context files
+- ERROR on gate failures or unresolved clarifications

--- a/.opencode/command/speckit.specify.md
+++ b/.opencode/command/speckit.specify.md
@@ -1,0 +1,327 @@
+---
+description: Create or update the feature specification from a natural language feature description.
+handoffs: 
+  - label: Build Technical Plan
+    agent: speckit.plan
+    prompt: Create a plan for the spec. I am building with...
+  - label: Clarify Spec Requirements
+    agent: speckit.clarify
+    prompt: Clarify specification requirements
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before specification)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_specify` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+The text the user typed after `/speckit.specify` in the triggering message **is** the feature description. Assume you always have it available in this conversation even if `$ARGUMENTS` appears literally below. Do not ask the user to repeat it unless they provided an empty command.
+
+Given that feature description, do this:
+
+1. **Generate a concise short name** (2-4 words) for the feature:
+   - Analyze the feature description and extract the most meaningful keywords
+   - Create a 2-4 word short name that captures the essence of the feature
+   - Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+   - Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+   - Keep it concise but descriptive enough to understand the feature at a glance
+   - Examples:
+     - "I want to add user authentication" → "user-auth"
+     - "Implement OAuth2 integration for the API" → "oauth2-api-integration"
+     - "Create a dashboard for analytics" → "analytics-dashboard"
+     - "Fix payment processing timeout bug" → "fix-payment-timeout"
+
+2. **Branch creation** (optional, via hook):
+
+   If a `before_specify` hook ran successfully in the Pre-Execution Checks above, it will have created/switched to a git branch and output JSON containing `BRANCH_NAME` and `FEATURE_NUM`. Note these values for reference, but the branch name does **not** dictate the spec directory name.
+
+   If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
+
+3. **Create the spec feature directory**:
+
+   Specs live under the default `specs/` directory unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
+   1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
+   2. Otherwise, auto-generate it under `specs/`:
+      - Check `.specify/init-options.json` for `branch_numbering`
+      - If `"timestamp"`: prefix is `YYYYMMDD-HHMMSS` (current timestamp)
+      - If `"sequential"` or absent: prefix is `NNN` (next available 3-digit number after scanning existing directories in `specs/`)
+      - Construct the directory name: `<prefix>-<short-name>` (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+      - Set `SPECIFY_FEATURE_DIRECTORY` to `specs/<directory-name>`
+
+   **Create the directory and spec file**:
+   - `mkdir -p SPECIFY_FEATURE_DIRECTORY`
+   - Copy `.specify/templates/spec-template.md` to `SPECIFY_FEATURE_DIRECTORY/spec.md` as the starting point
+   - Set `SPEC_FILE` to `SPECIFY_FEATURE_DIRECTORY/spec.md`
+   - Persist the resolved path to `.specify/feature.json`:
+     ```json
+     {
+       "feature_directory": "<resolved feature dir>"
+     }
+     ```
+     Write the actual resolved directory path value (for example, `specs/003-user-auth`), not the literal string `SPECIFY_FEATURE_DIRECTORY`.
+     This allows downstream commands (`/speckit.plan`, `/speckit.tasks`, etc.) to locate the feature directory without relying on git branch name conventions.
+
+   **IMPORTANT**:
+   - You must only create one feature per `/speckit.specify` invocation
+   - The spec directory name and the git branch name are independent — they may be the same but that is the user's choice
+   - The spec directory and file are always created by this command, never by the hook
+
+4. Load `.specify/templates/spec-template.md` to understand required sections.
+
+5. Follow this execution flow:
+    1. Parse user description from arguments
+       If empty: ERROR "No feature description provided"
+    2. Extract key concepts from description
+       Identify: actors, actions, data, constraints
+    3. For unclear aspects:
+       - Make informed guesses based on context and industry standards
+       - Only mark with [NEEDS CLARIFICATION: specific question] if:
+         - The choice significantly impacts feature scope or user experience
+         - Multiple reasonable interpretations exist with different implications
+         - No reasonable default exists
+       - **LIMIT: Maximum 3 [NEEDS CLARIFICATION] markers total**
+       - Prioritize clarifications by impact: scope > security/privacy > user experience > technical details
+    4. Fill User Scenarios & Testing section
+       If no clear user flow: ERROR "Cannot determine user scenarios"
+    5. Generate Functional Requirements
+       Each requirement must be testable
+       Use reasonable defaults for unspecified details (document assumptions in Assumptions section)
+    6. Define Success Criteria
+       Create measurable, technology-agnostic outcomes
+       Include both quantitative metrics (time, performance, volume) and qualitative measures (user satisfaction, task completion)
+       Each criterion must be verifiable without implementation details
+    7. Identify Key Entities (if data involved)
+    8. Return: SUCCESS (spec ready for planning)
+
+6. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.
+
+7. **Specification Quality Validation**: After writing the initial spec, validate it against quality criteria:
+
+   a. **Create Spec Quality Checklist**: Generate a checklist file at `SPECIFY_FEATURE_DIRECTORY/checklists/requirements.md` using the checklist template structure with these validation items:
+
+      ```markdown
+      # Specification Quality Checklist: [FEATURE NAME]
+      
+      **Purpose**: Validate specification completeness and quality before proceeding to planning
+      **Created**: [DATE]
+      **Feature**: [Link to spec.md]
+      
+      ## Content Quality
+      
+      - [ ] No implementation details (languages, frameworks, APIs)
+      - [ ] Focused on user value and business needs
+      - [ ] Written for non-technical stakeholders
+      - [ ] All mandatory sections completed
+      
+      ## Requirement Completeness
+      
+      - [ ] No [NEEDS CLARIFICATION] markers remain
+      - [ ] Requirements are testable and unambiguous
+      - [ ] Success criteria are measurable
+      - [ ] Success criteria are technology-agnostic (no implementation details)
+      - [ ] All acceptance scenarios are defined
+      - [ ] Edge cases are identified
+      - [ ] Scope is clearly bounded
+      - [ ] Dependencies and assumptions identified
+      
+      ## Feature Readiness
+      
+      - [ ] All functional requirements have clear acceptance criteria
+      - [ ] User scenarios cover primary flows
+      - [ ] Feature meets measurable outcomes defined in Success Criteria
+      - [ ] No implementation details leak into specification
+      
+      ## Notes
+      
+      - Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`
+      ```
+
+   b. **Run Validation Check**: Review the spec against each checklist item:
+      - For each item, determine if it passes or fails
+      - Document specific issues found (quote relevant spec sections)
+
+   c. **Handle Validation Results**:
+
+      - **If all items pass**: Mark checklist complete and proceed to step 7
+
+      - **If items fail (excluding [NEEDS CLARIFICATION])**:
+        1. List the failing items and specific issues
+        2. Update the spec to address each issue
+        3. Re-run validation until all items pass (max 3 iterations)
+        4. If still failing after 3 iterations, document remaining issues in checklist notes and warn user
+
+      - **If [NEEDS CLARIFICATION] markers remain**:
+        1. Extract all [NEEDS CLARIFICATION: ...] markers from the spec
+        2. **LIMIT CHECK**: If more than 3 markers exist, keep only the 3 most critical (by scope/security/UX impact) and make informed guesses for the rest
+        3. For each clarification needed (max 3), present options to user in this format:
+
+           ```markdown
+           ## Question [N]: [Topic]
+           
+           **Context**: [Quote relevant spec section]
+           
+           **What we need to know**: [Specific question from NEEDS CLARIFICATION marker]
+           
+           **Suggested Answers**:
+           
+           | Option | Answer | Implications |
+           |--------|--------|--------------|
+           | A      | [First suggested answer] | [What this means for the feature] |
+           | B      | [Second suggested answer] | [What this means for the feature] |
+           | C      | [Third suggested answer] | [What this means for the feature] |
+           | Custom | Provide your own answer | [Explain how to provide custom input] |
+           
+           **Your choice**: _[Wait for user response]_
+           ```
+
+        4. **CRITICAL - Table Formatting**: Ensure markdown tables are properly formatted:
+           - Use consistent spacing with pipes aligned
+           - Each cell should have spaces around content: `| Content |` not `|Content|`
+           - Header separator must have at least 3 dashes: `|--------|`
+           - Test that the table renders correctly in markdown preview
+        5. Number questions sequentially (Q1, Q2, Q3 - max 3 total)
+        6. Present all questions together before waiting for responses
+        7. Wait for user to respond with their choices for all questions (e.g., "Q1: A, Q2: Custom - [details], Q3: B")
+        8. Update the spec by replacing each [NEEDS CLARIFICATION] marker with the user's selected or provided answer
+        9. Re-run validation after all clarifications are resolved
+
+   d. **Update Checklist**: After each validation iteration, update the checklist file with current pass/fail status
+
+8. **Report completion** to the user with:
+   - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
+   - `SPEC_FILE` — the spec file path
+   - Checklist results summary
+   - Readiness for the next phase (`/speckit.clarify` or `/speckit.plan`)
+
+9. **Check for extension hooks**: After reporting completion, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_specify` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+**NOTE:** Branch creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+
+## Quick Guidelines
+
+- Focus on **WHAT** users need and **WHY**.
+- Avoid HOW to implement (no tech stack, APIs, code structure).
+- Written for business stakeholders, not developers.
+- DO NOT create any checklists that are embedded in the spec. That will be a separate command.
+
+### Section Requirements
+
+- **Mandatory sections**: Must be completed for every feature
+- **Optional sections**: Include only when relevant to the feature
+- When a section doesn't apply, remove it entirely (don't leave as "N/A")
+
+### For AI Generation
+
+When creating this spec from a user prompt:
+
+1. **Make informed guesses**: Use context, industry standards, and common patterns to fill gaps
+2. **Document assumptions**: Record reasonable defaults in the Assumptions section
+3. **Limit clarifications**: Maximum 3 [NEEDS CLARIFICATION] markers - use only for critical decisions that:
+   - Significantly impact feature scope or user experience
+   - Have multiple reasonable interpretations with different implications
+   - Lack any reasonable default
+4. **Prioritize clarifications**: scope > security/privacy > user experience > technical details
+5. **Think like a tester**: Every vague requirement should fail the "testable and unambiguous" checklist item
+6. **Common areas needing clarification** (only if no reasonable default exists):
+   - Feature scope and boundaries (include/exclude specific use cases)
+   - User types and permissions (if multiple conflicting interpretations possible)
+   - Security/compliance requirements (when legally/financially significant)
+
+**Examples of reasonable defaults** (don't ask about these):
+
+- Data retention: Industry-standard practices for the domain
+- Performance targets: Standard web/mobile app expectations unless specified
+- Error handling: User-friendly messages with appropriate fallbacks
+- Authentication method: Standard session-based or OAuth2 for web apps
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
+
+### Success Criteria Guidelines
+
+Success criteria must be:
+
+1. **Measurable**: Include specific metrics (time, percentage, count, rate)
+2. **Technology-agnostic**: No mention of frameworks, languages, databases, or tools
+3. **User-focused**: Describe outcomes from user/business perspective, not system internals
+4. **Verifiable**: Can be tested/validated without knowing implementation details
+
+**Good examples**:
+
+- "Users can complete checkout in under 3 minutes"
+- "System supports 10,000 concurrent users"
+- "95% of searches return results in under 1 second"
+- "Task completion rate improves by 40%"
+
+**Bad examples** (implementation-focused):
+
+- "API response time is under 200ms" (too technical, use "Users see results instantly")
+- "Database can handle 1000 TPS" (implementation detail, use user-facing metric)
+- "React components render efficiently" (framework-specific)
+- "Redis cache hit rate above 80%" (technology-specific)

--- a/.opencode/command/speckit.tasks.md
+++ b/.opencode/command/speckit.tasks.md
@@ -1,0 +1,200 @@
+---
+description: Generate an actionable, dependency-ordered tasks.md for the feature based on available design artifacts.
+handoffs: 
+  - label: Analyze For Consistency
+    agent: speckit.analyze
+    prompt: Run a project analysis for consistency
+    send: true
+  - label: Implement Project
+    agent: speckit.implement
+    prompt: Start the implementation in phases
+    send: true
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. **Setup**: Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+
+2. **Load design documents**: Read from FEATURE_DIR:
+   - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
+   - Note: Not all projects have all documents. Generate tasks based on what's available.
+
+3. **Execute task generation workflow**:
+   - Load plan.md and extract tech stack, libraries, project structure
+   - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
+   - If data-model.md exists: Extract entities and map to user stories
+   - If contracts/ exists: Map interface contracts to user stories
+   - If research.md exists: Extract decisions for setup tasks
+   - Generate tasks organized by user story (see Task Generation Rules below)
+   - Generate dependency graph showing user story completion order
+   - Create parallel execution examples per user story
+   - Validate task completeness (each user story has all needed tasks, independently testable)
+
+4. **Generate tasks.md**: Use `.specify/templates/tasks-template.md` as structure, fill with:
+   - Correct feature name from plan.md
+   - Phase 1: Setup tasks (project initialization)
+   - Phase 2: Foundational tasks (blocking prerequisites for all user stories)
+   - Phase 3+: One phase per user story (in priority order from spec.md)
+   - Each phase includes: story goal, independent test criteria, tests (if requested), implementation tasks
+   - Final Phase: Polish & cross-cutting concerns
+   - All tasks must follow the strict checklist format (see Task Generation Rules below)
+   - Clear file paths for each task
+   - Dependencies section showing story completion order
+   - Parallel execution examples per story
+   - Implementation strategy section (MVP first, incremental delivery)
+
+5. **Report**: Output path to generated tasks.md and summary:
+   - Total task count
+   - Task count per user story
+   - Parallel opportunities identified
+   - Independent test criteria for each story
+   - Suggested MVP scope (typically just User Story 1)
+   - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+Context for task generation: $ARGUMENTS
+
+The tasks.md should be immediately executable - each task must be specific enough that an LLM can complete it without additional context.
+
+## Task Generation Rules
+
+**CRITICAL**: Tasks MUST be organized by user story to enable independent implementation and testing.
+
+**Tests are OPTIONAL**: Only generate test tasks if explicitly requested in the feature specification or if user requests TDD approach.
+
+### Checklist Format (REQUIRED)
+
+Every task MUST strictly follow this format:
+
+```text
+- [ ] [TaskID] [P?] [Story?] Description with file path
+```
+
+**Format Components**:
+
+1. **Checkbox**: ALWAYS start with `- [ ]` (markdown checkbox)
+2. **Task ID**: Sequential number (T001, T002, T003...) in execution order
+3. **[P] marker**: Include ONLY if task is parallelizable (different files, no dependencies on incomplete tasks)
+4. **[Story] label**: REQUIRED for user story phase tasks only
+   - Format: [US1], [US2], [US3], etc. (maps to user stories from spec.md)
+   - Setup phase: NO story label
+   - Foundational phase: NO story label  
+   - User Story phases: MUST have story label
+   - Polish phase: NO story label
+5. **Description**: Clear action with exact file path
+
+**Examples**:
+
+- ✅ CORRECT: `- [ ] T001 Create project structure per implementation plan`
+- ✅ CORRECT: `- [ ] T005 [P] Implement authentication middleware in src/middleware/auth.py`
+- ✅ CORRECT: `- [ ] T012 [P] [US1] Create User model in src/models/user.py`
+- ✅ CORRECT: `- [ ] T014 [US1] Implement UserService in src/services/user_service.py`
+- ❌ WRONG: `- [ ] Create User model` (missing ID and Story label)
+- ❌ WRONG: `T001 [US1] Create model` (missing checkbox)
+- ❌ WRONG: `- [ ] [US1] Create User model` (missing Task ID)
+- ❌ WRONG: `- [ ] T001 [US1] Create model` (missing file path)
+
+### Task Organization
+
+1. **From User Stories (spec.md)** - PRIMARY ORGANIZATION:
+   - Each user story (P1, P2, P3...) gets its own phase
+   - Map all related components to their story:
+     - Models needed for that story
+     - Services needed for that story
+     - Interfaces/UI needed for that story
+     - If tests requested: Tests specific to that story
+   - Mark story dependencies (most stories should be independent)
+
+2. **From Contracts**:
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
+
+3. **From Data Model**:
+   - Map each entity to the user story(ies) that need it
+   - If entity serves multiple stories: Put in earliest story or Setup phase
+   - Relationships → service layer tasks in appropriate story phase
+
+4. **From Setup/Infrastructure**:
+   - Shared infrastructure → Setup phase (Phase 1)
+   - Foundational/blocking tasks → Foundational phase (Phase 2)
+   - Story-specific setup → within that story's phase
+
+### Phase Structure
+
+- **Phase 1**: Setup (project initialization)
+- **Phase 2**: Foundational (blocking prerequisites - MUST complete before user stories)
+- **Phase 3+**: User Stories in priority order (P1, P2, P3...)
+  - Within each story: Tests (if requested) → Models → Services → Endpoints → Integration
+  - Each phase should be a complete, independently testable increment
+- **Final Phase**: Polish & Cross-Cutting Concerns

--- a/.opencode/command/speckit.taskstoissues.md
+++ b/.opencode/command/speckit.taskstoissues.md
@@ -1,0 +1,96 @@
+---
+description: Convert existing tasks into actionable, dependency-ordered GitHub issues for the feature based on available design artifacts.
+tools: ['github/github-mcp-server/issue_write']
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks-to-issues conversion)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
+## Outline
+
+1. Run `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
+1. From the executed script, extract the path to **tasks**.
+1. Get the Git remote by running:
+
+```bash
+git config --get remote.origin.url
+```
+
+> [!CAUTION]
+> ONLY PROCEED TO NEXT STEPS IF THE REMOTE IS A GITHUB URL
+
+1. For each task in the list, use the GitHub MCP server to create a new issue in the repository that is representative of the Git remote.
+
+> [!CAUTION]
+> UNDER NO CIRCUMSTANCES EVER CREATE ISSUES IN REPOSITORIES THAT DO NOT MATCH THE REMOTE URL
+
+## Post-Execution Checks
+
+**Check for extension hooks (after tasks-to-issues conversion)**:
+Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.after_taskstoissues` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter out hooks where `enabled` is explicitly `false`. Treat hooks without an `enabled` field as enabled by default.
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -1,0 +1,148 @@
+installed: []
+settings:
+  auto_execute_hooks: true
+hooks:
+  before_constitution:
+  - extension: git
+    command: speckit.git.initialize
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.initialize?
+    description: Initialize Git repository before constitution setup
+    condition: null
+  before_specify:
+  - extension: git
+    command: speckit.git.feature
+    enabled: true
+    optional: false
+    prompt: Execute speckit.git.feature?
+    description: Create feature branch before specification
+    condition: null
+  before_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before clarification?
+    description: Auto-commit before spec clarification
+    condition: null
+  before_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before planning?
+    description: Auto-commit before implementation planning
+    condition: null
+  before_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before task generation?
+    description: Auto-commit before task generation
+    condition: null
+  before_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before implementation?
+    description: Auto-commit before implementation
+    condition: null
+  before_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before checklist?
+    description: Auto-commit before checklist generation
+    condition: null
+  before_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before analysis?
+    description: Auto-commit before analysis
+    condition: null
+  before_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit outstanding changes before issue sync?
+    description: Auto-commit before tasks-to-issues conversion
+    condition: null
+  after_constitution:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit constitution changes?
+    description: Auto-commit after constitution update
+    condition: null
+  after_specify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit specification changes?
+    description: Auto-commit after specification
+    condition: null
+  after_clarify:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit clarification changes?
+    description: Auto-commit after spec clarification
+    condition: null
+  after_plan:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit plan changes?
+    description: Auto-commit after implementation planning
+    condition: null
+  after_tasks:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit task changes?
+    description: Auto-commit after task generation
+    condition: null
+  after_implement:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit implementation changes?
+    description: Auto-commit after implementation
+    condition: null
+  after_checklist:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit checklist changes?
+    description: Auto-commit after checklist generation
+    condition: null
+  after_analyze:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit analysis results?
+    description: Auto-commit after analysis
+    condition: null
+  after_taskstoissues:
+  - extension: git
+    command: speckit.git.commit
+    enabled: true
+    optional: true
+    prompt: Commit after syncing issues?
+    description: Auto-commit after tasks-to-issues conversion
+    condition: null

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -1,0 +1,30 @@
+{
+  "schema_version": "1.0",
+  "extensions": {
+    "git": {
+      "version": "1.0.0",
+      "source": "local",
+      "manifest_hash": "sha256:9731aa8143a72fbebfdb440f155038ab42642517c2b2bdbbf67c8fdbe076ed79",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "claude": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ],
+        "codex": [
+          "speckit.git.feature",
+          "speckit.git.validate",
+          "speckit.git.remote",
+          "speckit.git.initialize",
+          "speckit.git.commit"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-04-18T14:01:02.726793+00:00"
+    }
+  }
+}

--- a/.specify/extensions/git/README.md
+++ b/.specify/extensions/git/README.md
@@ -1,0 +1,100 @@
+# Git Branching Workflow Extension
+
+Git repository initialization, feature branch creation, numbering (sequential/timestamp), validation, remote detection, and auto-commit for Spec Kit.
+
+## Overview
+
+This extension provides Git operations as an optional, self-contained module. It manages:
+
+- **Repository initialization** with configurable commit messages
+- **Feature branch creation** with sequential (`001-feature-name`) or timestamp (`20260319-143022-feature-name`) numbering
+- **Branch validation** to ensure branches follow naming conventions
+- **Git remote detection** for GitHub integration (e.g., issue creation)
+- **Auto-commit** after core commands (configurable per-command with custom messages)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `speckit.git.initialize` | Initialize a Git repository with a configurable commit message |
+| `speckit.git.feature` | Create a feature branch with sequential or timestamp numbering |
+| `speckit.git.validate` | Validate current branch follows feature branch naming conventions |
+| `speckit.git.remote` | Detect Git remote URL for GitHub integration |
+| `speckit.git.commit` | Auto-commit changes (configurable per-command enable/disable and messages) |
+
+## Hooks
+
+| Event | Command | Optional | Description |
+|-------|---------|----------|-------------|
+| `before_constitution` | `speckit.git.initialize` | No | Init git repo before constitution |
+| `before_specify` | `speckit.git.feature` | No | Create feature branch before specification |
+| `before_clarify` | `speckit.git.commit` | Yes | Commit outstanding changes before clarification |
+| `before_plan` | `speckit.git.commit` | Yes | Commit outstanding changes before planning |
+| `before_tasks` | `speckit.git.commit` | Yes | Commit outstanding changes before task generation |
+| `before_implement` | `speckit.git.commit` | Yes | Commit outstanding changes before implementation |
+| `before_checklist` | `speckit.git.commit` | Yes | Commit outstanding changes before checklist |
+| `before_analyze` | `speckit.git.commit` | Yes | Commit outstanding changes before analysis |
+| `before_taskstoissues` | `speckit.git.commit` | Yes | Commit outstanding changes before issue sync |
+| `after_constitution` | `speckit.git.commit` | Yes | Auto-commit after constitution update |
+| `after_specify` | `speckit.git.commit` | Yes | Auto-commit after specification |
+| `after_clarify` | `speckit.git.commit` | Yes | Auto-commit after clarification |
+| `after_plan` | `speckit.git.commit` | Yes | Auto-commit after planning |
+| `after_tasks` | `speckit.git.commit` | Yes | Auto-commit after task generation |
+| `after_implement` | `speckit.git.commit` | Yes | Auto-commit after implementation |
+| `after_checklist` | `speckit.git.commit` | Yes | Auto-commit after checklist |
+| `after_analyze` | `speckit.git.commit` | Yes | Auto-commit after analysis |
+| `after_taskstoissues` | `speckit.git.commit` | Yes | Auto-commit after issue sync |
+
+## Configuration
+
+Configuration is stored in `.specify/extensions/git/git-config.yml`:
+
+```yaml
+# Branch numbering strategy: "sequential" or "timestamp"
+branch_numbering: sequential
+
+# Custom commit message for git init
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit per command (all disabled by default)
+# Example: enable auto-commit after specify
+auto_commit:
+  default: false
+  after_specify:
+    enabled: true
+    message: "[Spec Kit] Add specification"
+```
+
+## Installation
+
+```bash
+# Install the bundled git extension (no network required)
+specify extension add git
+```
+
+## Disabling
+
+```bash
+# Disable the git extension (spec creation continues without branching)
+specify extension disable git
+
+# Re-enable it
+specify extension enable git
+```
+
+## Graceful Degradation
+
+When Git is not installed or the directory is not a Git repository:
+- Spec directories are still created under `specs/`
+- Branch creation is skipped with a warning
+- Branch validation is skipped with a warning
+- Remote detection returns empty results
+
+## Scripts
+
+The extension bundles cross-platform scripts:
+
+- `scripts/bash/create-new-feature.sh` — Bash implementation
+- `scripts/bash/git-common.sh` — Shared Git utilities (Bash)
+- `scripts/powershell/create-new-feature.ps1` — PowerShell implementation
+- `scripts/powershell/git-common.ps1` — Shared Git utilities (PowerShell)

--- a/.specify/extensions/git/commands/speckit.git.commit.md
+++ b/.specify/extensions/git/commands/speckit.git.commit.md
@@ -1,0 +1,48 @@
+---
+description: "Auto-commit changes after a Spec Kit command completes"
+---
+
+# Auto-Commit Changes
+
+Automatically stage and commit all changes after a Spec Kit command completes.
+
+## Behavior
+
+This command is invoked as a hook after (or before) core commands. It:
+
+1. Determines the event name from the hook context (e.g., if invoked as an `after_specify` hook, the event is `after_specify`; if `before_plan`, the event is `before_plan`)
+2. Checks `.specify/extensions/git/git-config.yml` for the `auto_commit` section
+3. Looks up the specific event key to see if auto-commit is enabled
+4. Falls back to `auto_commit.default` if no event-specific key exists
+5. Uses the per-command `message` if configured, otherwise a default message
+6. If enabled and there are uncommitted changes, runs `git add .` + `git commit`
+
+## Execution
+
+Determine the event name from the hook that triggered this command, then run the script:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/auto-commit.sh <event_name>`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/auto-commit.ps1 <event_name>`
+
+Replace `<event_name>` with the actual hook event (e.g., `after_specify`, `before_plan`, `after_implement`).
+
+## Configuration
+
+In `.specify/extensions/git/git-config.yml`:
+
+```yaml
+auto_commit:
+  default: false          # Global toggle — set true to enable for all commands
+  after_specify:
+    enabled: true          # Override per-command
+    message: "[Spec Kit] Add specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+```
+
+## Graceful Degradation
+
+- If Git is not available or the current directory is not a repository: skips with a warning
+- If no config file exists: skips (disabled by default)
+- If no changes to commit: skips with a message

--- a/.specify/extensions/git/commands/speckit.git.feature.md
+++ b/.specify/extensions/git/commands/speckit.git.feature.md
@@ -1,0 +1,67 @@
+---
+description: "Create a feature branch with sequential or timestamp numbering"
+---
+
+# Create Feature Branch
+
+Create and switch to a new git feature branch for the given specification. This command handles **branch creation only** — the spec directory and files are created by the core `/speckit.specify` workflow.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+You **MUST** consider the user input before proceeding (if not empty).
+
+## Environment Variable Override
+
+If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variable, argument, or in their request), pass it through to the script by setting the `GIT_BRANCH_NAME` environment variable before invoking the script. When `GIT_BRANCH_NAME` is set:
+- The script uses the exact value as the branch name, bypassing all prefix/suffix generation
+- `--short-name`, `--number`, and `--timestamp` flags are ignored
+- `FEATURE_NUM` is extracted from the name if it starts with a numeric prefix, otherwise set to the full branch name
+
+## Prerequisites
+
+- Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, warn the user and skip branch creation
+
+## Branch Numbering Mode
+
+Determine the branch numbering strategy by checking configuration in this order:
+
+1. Check `.specify/extensions/git/git-config.yml` for `branch_numbering` value
+2. Check `.specify/init-options.json` for `branch_numbering` value (backward compatibility)
+3. Default to `sequential` if neither exists
+
+## Execution
+
+Generate a concise short name (2-4 words) for the branch:
+- Analyze the feature description and extract the most meaningful keywords
+- Use action-noun format when possible (e.g., "add-user-auth", "fix-payment-bug")
+- Preserve technical terms and acronyms (OAuth2, API, JWT, etc.)
+
+Run the appropriate script based on your platform:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --short-name "<short-name>" "<feature description>"`
+- **Bash (timestamp)**: `.specify/extensions/git/scripts/bash/create-new-feature.sh --json --timestamp --short-name "<short-name>" "<feature description>"`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -ShortName "<short-name>" "<feature description>"`
+- **PowerShell (timestamp)**: `.specify/extensions/git/scripts/powershell/create-new-feature.ps1 -Json -Timestamp -ShortName "<short-name>" "<feature description>"`
+
+**IMPORTANT**:
+- Do NOT pass `--number` — the script determines the correct next number automatically
+- Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
+- You must only ever run this script once per feature
+- The JSON output will contain `BRANCH_NAME` and `FEATURE_NUM`
+
+## Graceful Degradation
+
+If Git is not installed or the current directory is not a Git repository:
+- Branch creation is skipped with a warning: `[specify] Warning: Git repository not detected; skipped branch creation`
+- The script still outputs `BRANCH_NAME` and `FEATURE_NUM` so the caller can reference them
+
+## Output
+
+The script outputs JSON with:
+- `BRANCH_NAME`: The branch name (e.g., `003-user-auth` or `20260319-143022-user-auth`)
+- `FEATURE_NUM`: The numeric or timestamp prefix used

--- a/.specify/extensions/git/commands/speckit.git.initialize.md
+++ b/.specify/extensions/git/commands/speckit.git.initialize.md
@@ -1,0 +1,49 @@
+---
+description: "Initialize a Git repository with an initial commit"
+---
+
+# Initialize Git Repository
+
+Initialize a Git repository in the current project directory if one does not already exist.
+
+## Execution
+
+Run the appropriate script from the project root:
+
+- **Bash**: `.specify/extensions/git/scripts/bash/initialize-repo.sh`
+- **PowerShell**: `.specify/extensions/git/scripts/powershell/initialize-repo.ps1`
+
+If the extension scripts are not found, fall back to:
+- **Bash**: `git init && git add . && git commit -m "Initial commit from Specify template"`
+- **PowerShell**: `git init; git add .; git commit -m "Initial commit from Specify template"`
+
+The script handles all checks internally:
+- Skips if Git is not available
+- Skips if already inside a Git repository
+- Runs `git init`, `git add .`, and `git commit` with an initial commit message
+
+## Customization
+
+Replace the script to add project-specific Git initialization steps:
+- Custom `.gitignore` templates
+- Default branch naming (`git config init.defaultBranch`)
+- Git LFS setup
+- Git hooks installation
+- Commit signing configuration
+- Git Flow initialization
+
+## Output
+
+On success:
+- `✓ Git repository initialized`
+
+## Graceful Degradation
+
+If Git is not installed:
+- Warn the user
+- Skip repository initialization
+- The project continues to function without Git (specs can still be created under `specs/`)
+
+If Git is installed but `git init`, `git add .`, or `git commit` fails:
+- Surface the error to the user
+- Stop this command rather than continuing with a partially initialized repository

--- a/.specify/extensions/git/commands/speckit.git.remote.md
+++ b/.specify/extensions/git/commands/speckit.git.remote.md
@@ -1,0 +1,45 @@
+---
+description: "Detect Git remote URL for GitHub integration"
+---
+
+# Detect Git Remote URL
+
+Detect the Git remote URL for integration with GitHub services (e.g., issue creation).
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and return empty:
+  ```
+  [specify] Warning: Git repository not detected; cannot determine remote URL
+  ```
+
+## Execution
+
+Run the following command to get the remote URL:
+
+```bash
+git config --get remote.origin.url
+```
+
+## Output
+
+Parse the remote URL and determine:
+
+1. **Repository owner**: Extract from the URL (e.g., `github` from `https://github.com/github/spec-kit.git`)
+2. **Repository name**: Extract from the URL (e.g., `spec-kit` from `https://github.com/github/spec-kit.git`)
+3. **Is GitHub**: Whether the remote points to a GitHub repository
+
+Supported URL formats:
+- HTTPS: `https://github.com/<owner>/<repo>.git`
+- SSH: `git@github.com:<owner>/<repo>.git`
+
+> [!CAUTION]
+> ONLY report a GitHub repository if the remote URL actually points to github.com.
+> Do NOT assume the remote is GitHub if the URL format doesn't match.
+
+## Graceful Degradation
+
+If Git is not installed, the directory is not a Git repository, or no remote is configured:
+- Return an empty result
+- Do NOT error — other workflows should continue without Git remote information

--- a/.specify/extensions/git/commands/speckit.git.validate.md
+++ b/.specify/extensions/git/commands/speckit.git.validate.md
@@ -1,0 +1,49 @@
+---
+description: "Validate current branch follows feature branch naming conventions"
+---
+
+# Validate Feature Branch
+
+Validate that the current Git branch follows the expected feature branch naming conventions.
+
+## Prerequisites
+
+- Check if Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
+- If Git is not available, output a warning and skip validation:
+  ```
+  [specify] Warning: Git repository not detected; skipped branch validation
+  ```
+
+## Validation Rules
+
+Get the current branch name:
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+The branch name must match one of these patterns:
+
+1. **Sequential**: `^[0-9]{3,}-` (e.g., `001-feature-name`, `042-fix-bug`, `1000-big-feature`)
+2. **Timestamp**: `^[0-9]{8}-[0-9]{6}-` (e.g., `20260319-143022-feature-name`)
+
+## Execution
+
+If on a feature branch (matches either pattern):
+- Output: `✓ On feature branch: <branch-name>`
+- Check if the corresponding spec directory exists under `specs/`:
+  - For sequential branches, look for `specs/<prefix>-*` where prefix matches the numeric portion
+  - For timestamp branches, look for `specs/<prefix>-*` where prefix matches the `YYYYMMDD-HHMMSS` portion
+- If spec directory exists: `✓ Spec directory found: <path>`
+- If spec directory missing: `⚠ No spec directory found for prefix <prefix>`
+
+If NOT on a feature branch:
+- Output: `✗ Not on a feature branch. Current branch: <branch-name>`
+- Output: `Feature branches should be named like: 001-feature-name or 20260319-143022-feature-name`
+
+## Graceful Degradation
+
+If Git is not installed or the directory is not a Git repository:
+- Check the `SPECIFY_FEATURE` environment variable as a fallback
+- If set, validate that value against the naming patterns
+- If not set, skip validation with a warning

--- a/.specify/extensions/git/config-template.yml
+++ b/.specify/extensions/git/config-template.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/extension.yml
+++ b/.specify/extensions/git/extension.yml
@@ -1,0 +1,140 @@
+schema_version: "1.0"
+
+extension:
+  id: git
+  name: "Git Branching Workflow"
+  version: "1.0.0"
+  description: "Feature branch creation, numbering (sequential/timestamp), validation, and Git remote detection"
+  author: spec-kit-core
+  repository: https://github.com/github/spec-kit
+  license: MIT
+
+requires:
+  speckit_version: ">=0.2.0"
+  tools:
+    - name: git
+      required: false
+
+provides:
+  commands:
+    - name: speckit.git.feature
+      file: commands/speckit.git.feature.md
+      description: "Create a feature branch with sequential or timestamp numbering"
+    - name: speckit.git.validate
+      file: commands/speckit.git.validate.md
+      description: "Validate current branch follows feature branch naming conventions"
+    - name: speckit.git.remote
+      file: commands/speckit.git.remote.md
+      description: "Detect Git remote URL for GitHub integration"
+    - name: speckit.git.initialize
+      file: commands/speckit.git.initialize.md
+      description: "Initialize a Git repository with an initial commit"
+    - name: speckit.git.commit
+      file: commands/speckit.git.commit.md
+      description: "Auto-commit changes after a Spec Kit command completes"
+
+  config:
+    - name: "git-config.yml"
+      template: "config-template.yml"
+      description: "Git branching configuration"
+      required: false
+
+hooks:
+  before_constitution:
+    command: speckit.git.initialize
+    optional: false
+    description: "Initialize Git repository before constitution setup"
+  before_specify:
+    command: speckit.git.feature
+    optional: false
+    description: "Create feature branch before specification"
+  before_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before clarification?"
+    description: "Auto-commit before spec clarification"
+  before_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before planning?"
+    description: "Auto-commit before implementation planning"
+  before_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before task generation?"
+    description: "Auto-commit before task generation"
+  before_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before implementation?"
+    description: "Auto-commit before implementation"
+  before_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before checklist?"
+    description: "Auto-commit before checklist generation"
+  before_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before analysis?"
+    description: "Auto-commit before analysis"
+  before_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit outstanding changes before issue sync?"
+    description: "Auto-commit before tasks-to-issues conversion"
+  after_constitution:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit constitution changes?"
+    description: "Auto-commit after constitution update"
+  after_specify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit specification changes?"
+    description: "Auto-commit after specification"
+  after_clarify:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit clarification changes?"
+    description: "Auto-commit after spec clarification"
+  after_plan:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit plan changes?"
+    description: "Auto-commit after implementation planning"
+  after_tasks:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit task changes?"
+    description: "Auto-commit after task generation"
+  after_implement:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit implementation changes?"
+    description: "Auto-commit after implementation"
+  after_checklist:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit checklist changes?"
+    description: "Auto-commit after checklist generation"
+  after_analyze:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit analysis results?"
+    description: "Auto-commit after analysis"
+  after_taskstoissues:
+    command: speckit.git.commit
+    optional: true
+    prompt: "Commit after syncing issues?"
+    description: "Auto-commit after tasks-to-issues conversion"
+
+tags:
+  - "git"
+  - "branching"
+  - "workflow"
+
+config:
+  defaults:
+    branch_numbering: sequential
+    init_commit_message: "[Spec Kit] Initial commit"

--- a/.specify/extensions/git/git-config.yml
+++ b/.specify/extensions/git/git-config.yml
@@ -1,0 +1,62 @@
+# Git Branching Workflow Extension Configuration
+# Copied to .specify/extensions/git/git-config.yml on install
+
+# Branch numbering strategy: "sequential" (001, 002, ...) or "timestamp" (YYYYMMDD-HHMMSS)
+branch_numbering: sequential
+
+# Commit message used by `git commit` during repository initialization
+init_commit_message: "[Spec Kit] Initial commit"
+
+# Auto-commit before/after core commands.
+# Set "default" to enable for all commands, then override per-command.
+# Each key can be true/false. Message is customizable per-command.
+auto_commit:
+  default: false
+  before_clarify:
+    enabled: false
+    message: "[Spec Kit] Save progress before clarification"
+  before_plan:
+    enabled: false
+    message: "[Spec Kit] Save progress before planning"
+  before_tasks:
+    enabled: false
+    message: "[Spec Kit] Save progress before task generation"
+  before_implement:
+    enabled: false
+    message: "[Spec Kit] Save progress before implementation"
+  before_checklist:
+    enabled: false
+    message: "[Spec Kit] Save progress before checklist"
+  before_analyze:
+    enabled: false
+    message: "[Spec Kit] Save progress before analysis"
+  before_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Save progress before issue sync"
+  after_constitution:
+    enabled: false
+    message: "[Spec Kit] Add project constitution"
+  after_specify:
+    enabled: false
+    message: "[Spec Kit] Add specification"
+  after_clarify:
+    enabled: false
+    message: "[Spec Kit] Clarify specification"
+  after_plan:
+    enabled: false
+    message: "[Spec Kit] Add implementation plan"
+  after_tasks:
+    enabled: false
+    message: "[Spec Kit] Add tasks"
+  after_implement:
+    enabled: false
+    message: "[Spec Kit] Implementation progress"
+  after_checklist:
+    enabled: false
+    message: "[Spec Kit] Add checklist"
+  after_analyze:
+    enabled: false
+    message: "[Spec Kit] Add analysis report"
+  after_taskstoissues:
+    enabled: false
+    message: "[Spec Kit] Sync tasks to issues"

--- a/.specify/extensions/git/scripts/bash/auto-commit.sh
+++ b/.specify/extensions/git/scripts/bash/auto-commit.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Git extension: auto-commit.sh
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.sh <event_name>
+#   e.g.: auto-commit.sh after_specify
+
+set -e
+
+EVENT_NAME="${1:-}"
+if [ -z "$EVENT_NAME" ]; then
+    echo "Usage: $0 <event_name>" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped auto-commit" >&2
+    exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Warning: Not a Git repository; skipped auto-commit" >&2
+    exit 0
+fi
+
+# Read per-command config from git-config.yml
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+_enabled=false
+_commit_msg=""
+
+if [ -f "$_config_file" ]; then
+    # Parse the auto_commit section for this event.
+    # Look for auto_commit.<event_name>.enabled and .message
+    # Also check auto_commit.default as fallback.
+    _in_auto_commit=false
+    _in_event=false
+    _default_enabled=false
+
+    while IFS= read -r _line; do
+        # Detect auto_commit: section
+        if echo "$_line" | grep -q '^auto_commit:'; then
+            _in_auto_commit=true
+            _in_event=false
+            continue
+        fi
+
+        # Exit auto_commit section on next top-level key
+        if $_in_auto_commit && echo "$_line" | grep -Eq '^[a-z]'; then
+            break
+        fi
+
+        if $_in_auto_commit; then
+            # Check default key
+            if echo "$_line" | grep -Eq "^[[:space:]]+default:[[:space:]]"; then
+                _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                [ "$_val" = "true" ] && _default_enabled=true
+            fi
+
+            # Detect our event subsection
+            if echo "$_line" | grep -Eq "^[[:space:]]+${EVENT_NAME}:"; then
+                _in_event=true
+                continue
+            fi
+
+            # Inside our event subsection
+            if $_in_event; then
+                # Exit on next sibling key (same indent level as event name)
+                if echo "$_line" | grep -Eq '^[[:space:]]{2}[a-z]' && ! echo "$_line" | grep -Eq '^[[:space:]]{4}'; then
+                    _in_event=false
+                    continue
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+enabled:'; then
+                    _val=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+                    [ "$_val" = "true" ] && _enabled=true
+                    [ "$_val" = "false" ] && _enabled=false
+                fi
+                if echo "$_line" | grep -Eq '[[:space:]]+message:'; then
+                    _commit_msg=$(echo "$_line" | sed 's/^[^:]*:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+                fi
+            fi
+        fi
+    done < "$_config_file"
+
+    # If event-specific key not found, use default
+    if [ "$_enabled" = "false" ] && [ "$_default_enabled" = "true" ]; then
+        # Only use default if the event wasn't explicitly set to false
+        # Check if event section existed at all
+        if ! grep -q "^[[:space:]]*${EVENT_NAME}:" "$_config_file" 2>/dev/null; then
+            _enabled=true
+        fi
+    fi
+else
+    # No config file — auto-commit disabled by default
+    exit 0
+fi
+
+if [ "$_enabled" != "true" ]; then
+    exit 0
+fi
+
+# Check if there are changes to commit
+if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet 2>/dev/null && [ -z "$(git ls-files --others --exclude-standard 2>/dev/null)" ]; then
+    echo "[specify] No changes to commit after $EVENT_NAME" >&2
+    exit 0
+fi
+
+# Derive a human-readable command name from the event
+# e.g., after_specify -> specify, before_plan -> plan
+_command_name=$(echo "$EVENT_NAME" | sed 's/^after_//' | sed 's/^before_//')
+_phase=$(echo "$EVENT_NAME" | grep -q '^before_' && echo 'before' || echo 'after')
+
+# Use custom message if configured, otherwise default
+if [ -z "$_commit_msg" ]; then
+    _commit_msg="[Spec Kit] Auto-commit ${_phase} ${_command_name}"
+fi
+
+# Stage and commit
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit -q -m "$_commit_msg" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "[OK] Changes committed ${_phase} ${_command_name}" >&2

--- a/.specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/.specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -1,0 +1,453 @@
+#!/usr/bin/env bash
+# Git extension: create-new-feature.sh
+# Adapted from core scripts/bash/create-new-feature.sh for extension layout.
+# Sources common.sh from the project's installed scripts, falling back to
+# git-common.sh for minimal git helpers.
+
+set -e
+
+JSON_MODE=false
+DRY_RUN=false
+ALLOW_EXISTING=false
+SHORT_NAME=""
+BRANCH_NUMBER=""
+USE_TIMESTAMP=false
+ARGS=()
+i=1
+while [ $i -le $# ]; do
+    arg="${!i}"
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            ;;
+        --allow-existing-branch)
+            ALLOW_EXISTING=true
+            ;;
+        --short-name)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            SHORT_NAME="$next_arg"
+            ;;
+        --number)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            BRANCH_NUMBER="$next_arg"
+            if [[ ! "$BRANCH_NUMBER" =~ ^[0-9]+$ ]]; then
+                echo 'Error: --number must be a non-negative integer' >&2
+                exit 1
+            fi
+            ;;
+        --timestamp)
+            USE_TIMESTAMP=true
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>"
+            echo ""
+            echo "Options:"
+            echo "  --json              Output in JSON format"
+            echo "  --dry-run           Compute branch name without creating the branch"
+            echo "  --allow-existing-branch  Switch to branch if it already exists instead of failing"
+            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+            echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --timestamp         Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+            echo "  --help, -h          Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+            echo ""
+            echo "Examples:"
+            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+            echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            echo "  $0 --timestamp --short-name 'user-auth' 'Add user authentication'"
+            echo "  GIT_BRANCH_NAME=my-branch $0 'feature description'"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+FEATURE_DESCRIPTION="${ARGS[*]}"
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Usage: $0 [--json] [--dry-run] [--allow-existing-branch] [--short-name <name>] [--number N] [--timestamp] <feature_description>" >&2
+    exit 1
+fi
+
+# Trim whitespace and validate description is not empty
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Error: Feature description cannot be empty or contain only whitespace" >&2
+    exit 1
+fi
+
+# Function to get highest number from specs directory
+get_highest_from_specs() {
+    local specs_dir="$1"
+    local highest=0
+
+    if [ -d "$specs_dir" ]; then
+        for dir in "$specs_dir"/*; do
+            [ -d "$dir" ] || continue
+            dirname=$(basename "$dir")
+            # Match sequential prefixes (>=3 digits), but skip timestamp dirs.
+            if echo "$dirname" | grep -Eq '^[0-9]{3,}-' && ! echo "$dirname" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+                number=$(echo "$dirname" | grep -Eo '^[0-9]+')
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
+            fi
+        done
+    fi
+
+    echo "$highest"
+}
+
+# Function to get highest number from git branches
+get_highest_from_branches() {
+    git branch -a 2>/dev/null | sed 's/^[* ]*//; s|^remotes/[^/]*/||' | _extract_highest_number
+}
+
+# Extract the highest sequential feature number from a list of ref names (one per line).
+_extract_highest_number() {
+    local highest=0
+    while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        if echo "$name" | grep -Eq '^[0-9]{3,}-' && ! echo "$name" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+            number=$(echo "$name" | grep -Eo '^[0-9]+' || echo "0")
+            number=$((10#$number))
+            if [ "$number" -gt "$highest" ]; then
+                highest=$number
+            fi
+        fi
+    done
+    echo "$highest"
+}
+
+# Function to get highest number from remote branches without fetching (side-effect-free)
+get_highest_from_remote_refs() {
+    local highest=0
+
+    for remote in $(git remote 2>/dev/null); do
+        local remote_highest
+        remote_highest=$(GIT_TERMINAL_PROMPT=0 git ls-remote --heads "$remote" 2>/dev/null | sed 's|.*refs/heads/||' | _extract_highest_number)
+        if [ "$remote_highest" -gt "$highest" ]; then
+            highest=$remote_highest
+        fi
+    done
+
+    echo "$highest"
+}
+
+# Function to check existing branches and return next available number.
+check_existing_branches() {
+    local specs_dir="$1"
+    local skip_fetch="${2:-false}"
+
+    if [ "$skip_fetch" = true ]; then
+        local highest_remote=$(get_highest_from_remote_refs)
+        local highest_branch=$(get_highest_from_branches)
+        if [ "$highest_remote" -gt "$highest_branch" ]; then
+            highest_branch=$highest_remote
+        fi
+    else
+        git fetch --all --prune >/dev/null 2>&1 || true
+        local highest_branch=$(get_highest_from_branches)
+    fi
+
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
+
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
+    fi
+
+    echo $((max_num + 1))
+}
+
+# Function to clean and format a branch name
+clean_branch_name() {
+    local name="$1"
+    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
+}
+
+# ---------------------------------------------------------------------------
+# Source common.sh for resolve_template, json_escape, get_repo_root, has_git.
+#
+# Search locations in priority order:
+#  1. .specify/scripts/bash/common.sh under the project root (installed project)
+#  2. scripts/bash/common.sh under the project root (source checkout fallback)
+#  3. git-common.sh next to this script (minimal fallback — lacks resolve_template)
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root by walking up from the script location
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+_common_loaded=false
+_PROJECT_ROOT=$(_find_project_root "$SCRIPT_DIR") || true
+
+if [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/.specify/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/.specify/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -n "$_PROJECT_ROOT" ] && [ -f "$_PROJECT_ROOT/scripts/bash/common.sh" ]; then
+    source "$_PROJECT_ROOT/scripts/bash/common.sh"
+    _common_loaded=true
+elif [ -f "$SCRIPT_DIR/git-common.sh" ]; then
+    source "$SCRIPT_DIR/git-common.sh"
+    _common_loaded=true
+fi
+
+if [ "$_common_loaded" != "true" ]; then
+    echo "Error: Could not locate common.sh or git-common.sh. Please ensure the Specify core scripts are installed." >&2
+    exit 1
+fi
+
+# Resolve repository root
+if type get_repo_root >/dev/null 2>&1; then
+    REPO_ROOT=$(get_repo_root)
+elif git rev-parse --show-toplevel >/dev/null 2>&1; then
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+elif [ -n "$_PROJECT_ROOT" ]; then
+    REPO_ROOT="$_PROJECT_ROOT"
+else
+    echo "Error: Could not determine repository root." >&2
+    exit 1
+fi
+
+# Check if git is available at this repo root
+if type has_git >/dev/null 2>&1; then
+    if has_git "$REPO_ROOT"; then
+        HAS_GIT=true
+    else
+        HAS_GIT=false
+    fi
+elif git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    HAS_GIT=true
+else
+    HAS_GIT=false
+fi
+
+cd "$REPO_ROOT"
+
+SPECS_DIR="$REPO_ROOT/specs"
+
+# Function to generate branch name with stop word filtering
+generate_branch_name() {
+    local description="$1"
+
+    local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
+
+    local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
+
+    local meaningful_words=()
+    for word in $clean_name; do
+        [ -z "$word" ] && continue
+        if ! echo "$word" | grep -qiE "$stop_words"; then
+            if [ ${#word} -ge 3 ]; then
+                meaningful_words+=("$word")
+            elif echo "$description" | grep -qw -- "${word^^}"; then
+                meaningful_words+=("$word")
+            fi
+        fi
+    done
+
+    if [ ${#meaningful_words[@]} -gt 0 ]; then
+        local max_words=3
+        if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
+
+        local result=""
+        local count=0
+        for word in "${meaningful_words[@]}"; do
+            if [ $count -ge $max_words ]; then break; fi
+            if [ -n "$result" ]; then result="$result-"; fi
+            result="$result$word"
+            count=$((count + 1))
+        done
+        echo "$result"
+    else
+        local cleaned=$(clean_branch_name "$description")
+        echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+    fi
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if [ -n "${GIT_BRANCH_NAME:-}" ]; then
+    BRANCH_NAME="$GIT_BRANCH_NAME"
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^[0-9]+ pattern
+    if echo "$BRANCH_NAME" | grep -Eq '^[0-9]{8}-[0-9]{6}-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]{8}-[0-9]{6}')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    elif echo "$BRANCH_NAME" | grep -Eq '^[0-9]+-'; then
+        FEATURE_NUM=$(echo "$BRANCH_NAME" | grep -Eo '^[0-9]+')
+        BRANCH_SUFFIX="${BRANCH_NAME#${FEATURE_NUM}-}"
+    else
+        FEATURE_NUM="$BRANCH_NAME"
+        BRANCH_SUFFIX="$BRANCH_NAME"
+    fi
+else
+    # Generate branch name
+    if [ -n "$SHORT_NAME" ]; then
+        BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
+    else
+        BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
+    fi
+
+    # Warn if --number and --timestamp are both specified
+    if [ "$USE_TIMESTAMP" = true ] && [ -n "$BRANCH_NUMBER" ]; then
+        >&2 echo "[specify] Warning: --number is ignored when --timestamp is used"
+        BRANCH_NUMBER=""
+    fi
+
+    # Determine branch prefix
+    if [ "$USE_TIMESTAMP" = true ]; then
+        FEATURE_NUM=$(date +%Y%m%d-%H%M%S)
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    else
+        if [ -z "$BRANCH_NUMBER" ]; then
+            if [ "$DRY_RUN" = true ] && [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR" true)
+            elif [ "$DRY_RUN" = true ]; then
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            elif [ "$HAS_GIT" = true ]; then
+                BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+            else
+                HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+                BRANCH_NUMBER=$((HIGHEST + 1))
+            fi
+        fi
+
+        FEATURE_NUM=$(printf "%03d" "$((10#$BRANCH_NUMBER))")
+        BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+    fi
+fi
+
+# GitHub enforces a 244-byte limit on branch names
+MAX_BRANCH_LENGTH=244
+_byte_length() { printf '%s' "$1" | LC_ALL=C wc -c | tr -d ' '; }
+BRANCH_BYTE_LEN=$(_byte_length "$BRANCH_NAME")
+if [ -n "${GIT_BRANCH_NAME:-}" ] && [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    >&2 echo "Error: GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is ${BRANCH_BYTE_LEN} bytes."
+    exit 1
+elif [ "$BRANCH_BYTE_LEN" -gt $MAX_BRANCH_LENGTH ]; then
+    PREFIX_LENGTH=$(( ${#FEATURE_NUM} + 1 ))
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - PREFIX_LENGTH))
+
+    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+
+    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+
+    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+fi
+
+if [ "$DRY_RUN" != true ]; then
+    if [ "$HAS_GIT" = true ]; then
+        branch_create_error=""
+        if ! branch_create_error=$(git checkout -q -b "$BRANCH_NAME" 2>&1); then
+            current_branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+            if git branch --list "$BRANCH_NAME" | grep -q .; then
+                if [ "$ALLOW_EXISTING" = true ]; then
+                    if [ "$current_branch" = "$BRANCH_NAME" ]; then
+                        :
+                    elif ! switch_branch_error=$(git checkout -q "$BRANCH_NAME" 2>&1); then
+                        >&2 echo "Error: Failed to switch to existing branch '$BRANCH_NAME'. Please resolve any local changes or conflicts and try again."
+                        if [ -n "$switch_branch_error" ]; then
+                            >&2 printf '%s\n' "$switch_branch_error"
+                        fi
+                        exit 1
+                    fi
+                elif [ "$USE_TIMESTAMP" = true ]; then
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Rerun to get a new timestamp or use a different --short-name."
+                    exit 1
+                else
+                    >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+                    exit 1
+                fi
+            else
+                >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'."
+                if [ -n "$branch_create_error" ]; then
+                    >&2 printf '%s\n' "$branch_create_error"
+                else
+                    >&2 echo "Please check your git configuration and try again."
+                fi
+                exit 1
+            fi
+        fi
+    else
+        >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    fi
+
+    printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
+fi
+
+if $JSON_MODE; then
+    if command -v jq >/dev/null 2>&1; then
+        if [ "$DRY_RUN" = true ]; then
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num,DRY_RUN:true}'
+        else
+            jq -cn \
+                --arg branch_name "$BRANCH_NAME" \
+                --arg feature_num "$FEATURE_NUM" \
+                '{BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num}'
+        fi
+    else
+        if type json_escape >/dev/null 2>&1; then
+            _je_branch=$(json_escape "$BRANCH_NAME")
+            _je_num=$(json_escape "$FEATURE_NUM")
+        else
+            _je_branch="$BRANCH_NAME"
+            _je_num="$FEATURE_NUM"
+        fi
+        if [ "$DRY_RUN" = true ]; then
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","DRY_RUN":true}\n' "$_je_branch" "$_je_num"
+        else
+            printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s"}\n' "$_je_branch" "$_je_num"
+        fi
+    fi
+else
+    echo "BRANCH_NAME: $BRANCH_NAME"
+    echo "FEATURE_NUM: $FEATURE_NUM"
+    if [ "$DRY_RUN" != true ]; then
+        printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
+    fi
+fi

--- a/.specify/extensions/git/scripts/bash/git-common.sh
+++ b/.specify/extensions/git/scripts/bash/git-common.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git-specific common functions for the git extension.
+# Extracted from scripts/bash/common.sh — contains only git-specific
+# branch validation and detection logic.
+
+# Check if we have git available at the repo root
+has_git() {
+    local repo_root="${1:-$(pwd)}"
+    { [ -d "$repo_root/.git" ] || [ -f "$repo_root/.git" ]; } && \
+        command -v git >/dev/null 2>&1 && \
+        git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# Strip a single optional path segment (e.g. gitflow "feat/004-name" -> "004-name").
+# Only when the full name is exactly two slash-free segments; otherwise returns the raw name.
+spec_kit_effective_branch_name() {
+    local raw="$1"
+    if [[ "$raw" =~ ^([^/]+)/([^/]+)$ ]]; then
+        printf '%s\n' "${BASH_REMATCH[2]}"
+    else
+        printf '%s\n' "$raw"
+    fi
+}
+
+# Validate that a branch name matches the expected feature branch pattern.
+# Accepts sequential (###-* with >=3 digits) or timestamp (YYYYMMDD-HHMMSS-*) formats.
+# Logic aligned with scripts/bash/common.sh check_feature_branch after effective-name normalization.
+check_feature_branch() {
+    local raw="$1"
+    local has_git_repo="$2"
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if [[ "$has_git_repo" != "true" ]]; then
+        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+        return 0
+    fi
+
+    local branch
+    branch=$(spec_kit_effective_branch_name "$raw")
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    local is_sequential=false
+    if [[ "$branch" =~ ^[0-9]{3,}- ]] && [[ ! "$branch" =~ ^[0-9]{7}-[0-9]{6}- ]] && [[ ! "$branch" =~ ^[0-9]{7,8}-[0-9]{6}$ ]]; then
+        is_sequential=true
+    fi
+    if [[ "$is_sequential" != "true" ]] && [[ ! "$branch" =~ ^[0-9]{8}-[0-9]{6}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: $raw" >&2
+        echo "Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name" >&2
+        return 1
+    fi
+
+    return 0
+}

--- a/.specify/extensions/git/scripts/bash/initialize-repo.sh
+++ b/.specify/extensions/git/scripts/bash/initialize-repo.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Git extension: initialize-repo.sh
+# Initialize a Git repository with an initial commit.
+# Customizable — replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+
+set -e
+
+SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Find project root
+_find_project_root() {
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.specify" ] || [ -d "$dir/.git" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
+cd "$REPO_ROOT"
+
+# Read commit message from extension config, fall back to default
+COMMIT_MSG="[Spec Kit] Initial commit"
+_config_file="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+if [ -f "$_config_file" ]; then
+    _msg=$(grep '^init_commit_message:' "$_config_file" 2>/dev/null | sed 's/^init_commit_message:[[:space:]]*//' | sed 's/^["'\'']//' | sed 's/["'\'']*$//')
+    if [ -n "$_msg" ]; then
+        COMMIT_MSG="$_msg"
+    fi
+fi
+
+# Check if git is available
+if ! command -v git >/dev/null 2>&1; then
+    echo "[specify] Warning: Git not found; skipped repository initialization" >&2
+    exit 0
+fi
+
+# Check if already a git repo
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "[specify] Git repository already initialized; skipping" >&2
+    exit 0
+fi
+
+# Initialize
+_git_out=$(git init -q 2>&1) || { echo "[specify] Error: git init failed: $_git_out" >&2; exit 1; }
+_git_out=$(git add . 2>&1) || { echo "[specify] Error: git add failed: $_git_out" >&2; exit 1; }
+_git_out=$(git commit --allow-empty -q -m "$COMMIT_MSG" 2>&1) || { echo "[specify] Error: git commit failed: $_git_out" >&2; exit 1; }
+
+echo "✓ Git repository initialized" >&2

--- a/.specify/extensions/git/scripts/powershell/auto-commit.ps1
+++ b/.specify/extensions/git/scripts/powershell/auto-commit.ps1
@@ -1,0 +1,169 @@
+#!/usr/bin/env pwsh
+# Git extension: auto-commit.ps1
+# Automatically commit changes after a Spec Kit command completes.
+# Checks per-command config keys in git-config.yml before committing.
+#
+# Usage: auto-commit.ps1 <event_name>
+#   e.g.: auto-commit.ps1 after_specify
+param(
+    [Parameter(Position = 0, Mandatory = $true)]
+    [string]$EventName
+)
+$ErrorActionPreference = 'Stop'
+
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped auto-commit"
+    exit 0
+}
+
+# Temporarily relax ErrorActionPreference so git stderr warnings
+# (e.g. CRLF notices on Windows) do not become terminating errors.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    $isRepo = $LASTEXITCODE -eq 0
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+if (-not $isRepo) {
+    Write-Warning "[specify] Warning: Not a Git repository; skipped auto-commit"
+    exit 0
+}
+
+# Read per-command config from git-config.yml
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+$enabled = $false
+$commitMsg = ""
+
+if (Test-Path $configFile) {
+    # Parse YAML to find auto_commit section
+    $inAutoCommit = $false
+    $inEvent = $false
+    $defaultEnabled = $false
+
+    foreach ($line in Get-Content $configFile) {
+        # Detect auto_commit: section
+        if ($line -match '^auto_commit:') {
+            $inAutoCommit = $true
+            $inEvent = $false
+            continue
+        }
+
+        # Exit auto_commit section on next top-level key
+        if ($inAutoCommit -and $line -match '^[a-z]') {
+            break
+        }
+
+        if ($inAutoCommit) {
+            # Check default key
+            if ($line -match '^\s+default:\s*(.+)$') {
+                $val = $matches[1].Trim().ToLower()
+                if ($val -eq 'true') { $defaultEnabled = $true }
+            }
+
+            # Detect our event subsection
+            if ($line -match "^\s+${EventName}:") {
+                $inEvent = $true
+                continue
+            }
+
+            # Inside our event subsection
+            if ($inEvent) {
+                # Exit on next sibling key (2-space indent, not 4+)
+                if ($line -match '^\s{2}[a-z]' -and $line -notmatch '^\s{4}') {
+                    $inEvent = $false
+                    continue
+                }
+                if ($line -match '\s+enabled:\s*(.+)$') {
+                    $val = $matches[1].Trim().ToLower()
+                    if ($val -eq 'true') { $enabled = $true }
+                    if ($val -eq 'false') { $enabled = $false }
+                }
+                if ($line -match '\s+message:\s*(.+)$') {
+                    $commitMsg = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+                }
+            }
+        }
+    }
+
+    # If event-specific key not found, use default
+    if (-not $enabled -and $defaultEnabled) {
+        $hasEventKey = Select-String -Path $configFile -Pattern "^\s*${EventName}:" -Quiet
+        if (-not $hasEventKey) {
+            $enabled = $true
+        }
+    }
+} else {
+    # No config file — auto-commit disabled by default
+    exit 0
+}
+
+if (-not $enabled) {
+    exit 0
+}
+
+# Check if there are changes to commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    git diff --quiet HEAD 2>$null; $d1 = $LASTEXITCODE
+    git diff --cached --quiet 2>$null; $d2 = $LASTEXITCODE
+    $untracked = git ls-files --others --exclude-standard 2>$null
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+if ($d1 -eq 0 -and $d2 -eq 0 -and -not $untracked) {
+    Write-Host "[specify] No changes to commit after $EventName" -ForegroundColor DarkGray
+    exit 0
+}
+
+# Derive a human-readable command name from the event
+$commandName = $EventName -replace '^after_', '' -replace '^before_', ''
+$phase = if ($EventName -match '^before_') { 'before' } else { 'after' }
+
+# Use custom message if configured, otherwise default
+if (-not $commitMsg) {
+    $commitMsg = "[Spec Kit] Auto-commit $phase $commandName"
+}
+
+# Stage and commit
+# Relax ErrorActionPreference so CRLF warnings on stderr do not terminate,
+# while still allowing redirected error output to be captured for diagnostics.
+$savedEAP = $ErrorActionPreference
+$ErrorActionPreference = 'Continue'
+try {
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+} finally {
+    $ErrorActionPreference = $savedEAP
+}
+
+Write-Host "[OK] Changes committed $phase $commandName"

--- a/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
+++ b/.specify/extensions/git/scripts/powershell/create-new-feature.ps1
@@ -1,0 +1,403 @@
+#!/usr/bin/env pwsh
+# Git extension: create-new-feature.ps1
+# Adapted from core scripts/powershell/create-new-feature.ps1 for extension layout.
+# Sources common.ps1 from the project's installed scripts, falling back to
+# git-common.ps1 for minimal git helpers.
+[CmdletBinding()]
+param(
+    [switch]$Json,
+    [switch]$AllowExistingBranch,
+    [switch]$DryRun,
+    [string]$ShortName,
+    [Parameter()]
+    [long]$Number = 0,
+    [switch]$Timestamp,
+    [switch]$Help,
+    [Parameter(Position = 0, ValueFromRemainingArguments = $true)]
+    [string[]]$FeatureDescription
+)
+$ErrorActionPreference = 'Stop'
+
+if ($Help) {
+    Write-Host "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    Write-Host ""
+    Write-Host "Options:"
+    Write-Host "  -Json               Output in JSON format"
+    Write-Host "  -DryRun             Compute branch name without creating the branch"
+    Write-Host "  -AllowExistingBranch  Switch to branch if it already exists instead of failing"
+    Write-Host "  -ShortName <name>   Provide a custom short name (2-4 words) for the branch"
+    Write-Host "  -Number N           Specify branch number manually (overrides auto-detection)"
+    Write-Host "  -Timestamp          Use timestamp prefix (YYYYMMDD-HHMMSS) instead of sequential numbering"
+    Write-Host "  -Help               Show this help message"
+    Write-Host ""
+    Write-Host "Environment variables:"
+    Write-Host "  GIT_BRANCH_NAME     Use this exact branch name, bypassing all prefix/suffix generation"
+    Write-Host ""
+    exit 0
+}
+
+if (-not $FeatureDescription -or $FeatureDescription.Count -eq 0) {
+    Write-Error "Usage: ./create-new-feature.ps1 [-Json] [-DryRun] [-AllowExistingBranch] [-ShortName <name>] [-Number N] [-Timestamp] <feature description>"
+    exit 1
+}
+
+$featureDesc = ($FeatureDescription -join ' ').Trim()
+
+if ([string]::IsNullOrWhiteSpace($featureDesc)) {
+    Write-Error "Error: Feature description cannot be empty or contain only whitespace"
+    exit 1
+}
+
+function Get-HighestNumberFromSpecs {
+    param([string]$SpecsDir)
+
+    [long]$highest = 0
+    if (Test-Path $SpecsDir) {
+        Get-ChildItem -Path $SpecsDir -Directory | ForEach-Object {
+            if ($_.Name -match '^(\d{3,})-' -and $_.Name -notmatch '^\d{8}-\d{6}-') {
+                [long]$num = 0
+                if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                    $highest = $num
+                }
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromNames {
+    param([string[]]$Names)
+
+    [long]$highest = 0
+    foreach ($name in $Names) {
+        if ($name -match '^(\d{3,})-' -and $name -notmatch '^\d{8}-\d{6}-') {
+            [long]$num = 0
+            if ([long]::TryParse($matches[1], [ref]$num) -and $num -gt $highest) {
+                $highest = $num
+            }
+        }
+    }
+    return $highest
+}
+
+function Get-HighestNumberFromBranches {
+    param()
+
+    try {
+        $branches = git branch -a 2>$null
+        if ($LASTEXITCODE -eq 0 -and $branches) {
+            $cleanNames = $branches | ForEach-Object {
+                $_.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
+            }
+            return Get-HighestNumberFromNames -Names $cleanNames
+        }
+    } catch {
+        Write-Verbose "Could not check Git branches: $_"
+    }
+    return 0
+}
+
+function Get-HighestNumberFromRemoteRefs {
+    [long]$highest = 0
+    try {
+        $remotes = git remote 2>$null
+        if ($remotes) {
+            foreach ($remote in $remotes) {
+                $env:GIT_TERMINAL_PROMPT = '0'
+                $refs = git ls-remote --heads $remote 2>$null
+                $env:GIT_TERMINAL_PROMPT = $null
+                if ($LASTEXITCODE -eq 0 -and $refs) {
+                    $refNames = $refs | ForEach-Object {
+                        if ($_ -match 'refs/heads/(.+)$') { $matches[1] }
+                    } | Where-Object { $_ }
+                    $remoteHighest = Get-HighestNumberFromNames -Names $refNames
+                    if ($remoteHighest -gt $highest) { $highest = $remoteHighest }
+                }
+            }
+        }
+    } catch {
+        Write-Verbose "Could not query remote refs: $_"
+    }
+    return $highest
+}
+
+function Get-NextBranchNumber {
+    param(
+        [string]$SpecsDir,
+        [switch]$SkipFetch
+    )
+
+    if ($SkipFetch) {
+        $highestBranch = Get-HighestNumberFromBranches
+        $highestRemote = Get-HighestNumberFromRemoteRefs
+        $highestBranch = [Math]::Max($highestBranch, $highestRemote)
+    } else {
+        try {
+            git fetch --all --prune 2>$null | Out-Null
+        } catch { }
+        $highestBranch = Get-HighestNumberFromBranches
+    }
+
+    $highestSpec = Get-HighestNumberFromSpecs -SpecsDir $SpecsDir
+    $maxNum = [Math]::Max($highestBranch, $highestSpec)
+    return $maxNum + 1
+}
+
+function ConvertTo-CleanBranchName {
+    param([string]$Name)
+    return $Name.ToLower() -replace '[^a-z0-9]', '-' -replace '-{2,}', '-' -replace '^-', '' -replace '-$', ''
+}
+
+# ---------------------------------------------------------------------------
+# Source common.ps1 from the project's installed scripts.
+# Search locations in priority order:
+#  1. .specify/scripts/powershell/common.ps1 under the project root
+#  2. scripts/powershell/common.ps1 under the project root (source checkout)
+#  3. git-common.ps1 next to this script (minimal fallback)
+# ---------------------------------------------------------------------------
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$projectRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+$commonLoaded = $false
+
+if ($projectRoot) {
+    $candidates = @(
+        (Join-Path $projectRoot ".specify/scripts/powershell/common.ps1"),
+        (Join-Path $projectRoot "scripts/powershell/common.ps1")
+    )
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            . $candidate
+            $commonLoaded = $true
+            break
+        }
+    }
+}
+
+if (-not $commonLoaded -and (Test-Path "$PSScriptRoot/git-common.ps1")) {
+    . "$PSScriptRoot/git-common.ps1"
+    $commonLoaded = $true
+}
+
+if (-not $commonLoaded) {
+    throw "Unable to locate common script file. Please ensure the Specify core scripts are installed."
+}
+
+# Resolve repository root
+if (Get-Command Get-RepoRoot -ErrorAction SilentlyContinue) {
+    $repoRoot = Get-RepoRoot
+} elseif ($projectRoot) {
+    $repoRoot = $projectRoot
+} else {
+    throw "Could not determine repository root."
+}
+
+# Check if git is available
+if (Get-Command Test-HasGit -ErrorAction SilentlyContinue) {
+    # Call without parameters for compatibility with core common.ps1 (no -RepoRoot param)
+    # and git-common.ps1 (has -RepoRoot param with default).
+    $hasGit = Test-HasGit
+} else {
+    try {
+        git -C $repoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        $hasGit = ($LASTEXITCODE -eq 0)
+    } catch {
+        $hasGit = $false
+    }
+}
+
+Set-Location $repoRoot
+
+$specsDir = Join-Path $repoRoot 'specs'
+
+function Get-BranchName {
+    param([string]$Description)
+
+    $stopWords = @(
+        'i', 'a', 'an', 'the', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
+        'is', 'are', 'was', 'were', 'be', 'been', 'being', 'have', 'has', 'had',
+        'do', 'does', 'did', 'will', 'would', 'should', 'could', 'can', 'may', 'might', 'must', 'shall',
+        'this', 'that', 'these', 'those', 'my', 'your', 'our', 'their',
+        'want', 'need', 'add', 'get', 'set'
+    )
+
+    $cleanName = $Description.ToLower() -replace '[^a-z0-9\s]', ' '
+    $words = $cleanName -split '\s+' | Where-Object { $_ }
+
+    $meaningfulWords = @()
+    foreach ($word in $words) {
+        if ($stopWords -contains $word) { continue }
+        if ($word.Length -ge 3) {
+            $meaningfulWords += $word
+        } elseif ($Description -match "\b$($word.ToUpper())\b") {
+            $meaningfulWords += $word
+        }
+    }
+
+    if ($meaningfulWords.Count -gt 0) {
+        $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
+        $result = ($meaningfulWords | Select-Object -First $maxWords) -join '-'
+        return $result
+    } else {
+        $result = ConvertTo-CleanBranchName -Name $Description
+        $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
+        return [string]::Join('-', $fallbackWords)
+    }
+}
+
+# Check for GIT_BRANCH_NAME env var override (exact branch name, no prefix/suffix)
+if ($env:GIT_BRANCH_NAME) {
+    $branchName = $env:GIT_BRANCH_NAME
+    # Check 244-byte limit (UTF-8) for override names
+    $branchNameUtf8ByteCount = [System.Text.Encoding]::UTF8.GetByteCount($branchName)
+    if ($branchNameUtf8ByteCount -gt 244) {
+        throw "GIT_BRANCH_NAME must be 244 bytes or fewer in UTF-8. Provided value is $branchNameUtf8ByteCount bytes; please supply a shorter override branch name."
+    }
+    # Extract FEATURE_NUM from the branch name if it starts with a numeric prefix
+    # Check timestamp pattern first (YYYYMMDD-HHMMSS-) since it also matches the simpler ^\d+ pattern
+    if ($branchName -match '^(\d{8}-\d{6})-') {
+        $featureNum = $matches[1]
+    } elseif ($branchName -match '^(\d+)-') {
+        $featureNum = $matches[1]
+    } else {
+        $featureNum = $branchName
+    }
+} else {
+    if ($ShortName) {
+        $branchSuffix = ConvertTo-CleanBranchName -Name $ShortName
+    } else {
+        $branchSuffix = Get-BranchName -Description $featureDesc
+    }
+
+    if ($Timestamp -and $Number -ne 0) {
+        Write-Warning "[specify] Warning: -Number is ignored when -Timestamp is used"
+        $Number = 0
+    }
+
+    if ($Timestamp) {
+        $featureNum = Get-Date -Format 'yyyyMMdd-HHmmss'
+        $branchName = "$featureNum-$branchSuffix"
+    } else {
+        if ($Number -eq 0) {
+            if ($DryRun -and $hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir -SkipFetch
+            } elseif ($DryRun) {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            } elseif ($hasGit) {
+                $Number = Get-NextBranchNumber -SpecsDir $specsDir
+            } else {
+                $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
+            }
+        }
+
+        $featureNum = ('{0:000}' -f $Number)
+        $branchName = "$featureNum-$branchSuffix"
+    }
+}
+
+$maxBranchLength = 244
+if ($branchName.Length -gt $maxBranchLength) {
+    $prefixLength = $featureNum.Length + 1
+    $maxSuffixLength = $maxBranchLength - $prefixLength
+
+    $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
+    $truncatedSuffix = $truncatedSuffix -replace '-$', ''
+
+    $originalBranchName = $branchName
+    $branchName = "$featureNum-$truncatedSuffix"
+
+    Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
+    Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"
+    Write-Warning "[specify] Truncated to: $branchName ($($branchName.Length) bytes)"
+}
+
+if (-not $DryRun) {
+    if ($hasGit) {
+        $branchCreated = $false
+        $branchCreateError = ''
+        try {
+            $branchCreateError = git checkout -q -b $branchName 2>&1 | Out-String
+            if ($LASTEXITCODE -eq 0) {
+                $branchCreated = $true
+            }
+        } catch {
+            $branchCreateError = $_.Exception.Message
+        }
+
+        if (-not $branchCreated) {
+            $currentBranch = ''
+            try { $currentBranch = (git rev-parse --abbrev-ref HEAD 2>$null).Trim() } catch {}
+            $existingBranch = git branch --list $branchName 2>$null
+            if ($existingBranch) {
+                if ($AllowExistingBranch) {
+                    if ($currentBranch -eq $branchName) {
+                        # Already on the target branch
+                    } else {
+                        $switchBranchError = git checkout -q $branchName 2>&1 | Out-String
+                        if ($LASTEXITCODE -ne 0) {
+                            if ($switchBranchError) {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out.`n$($switchBranchError.Trim())"
+                            } else {
+                                Write-Error "Error: Branch '$branchName' exists but could not be checked out. Resolve any uncommitted changes or conflicts and try again."
+                            }
+                            exit 1
+                        }
+                    }
+                } elseif ($Timestamp) {
+                    Write-Error "Error: Branch '$branchName' already exists. Rerun to get a new timestamp or use a different -ShortName."
+                    exit 1
+                } else {
+                    Write-Error "Error: Branch '$branchName' already exists. Please use a different feature name or specify a different number with -Number."
+                    exit 1
+                }
+            } else {
+                if ($branchCreateError) {
+                    Write-Error "Error: Failed to create git branch '$branchName'.`n$($branchCreateError.Trim())"
+                } else {
+                    Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
+                }
+                exit 1
+            }
+        }
+    } else {
+        if ($Json) {
+            [Console]::Error.WriteLine("[specify] Warning: Git repository not detected; skipped branch creation for $branchName")
+        } else {
+            Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
+        }
+    }
+
+    $env:SPECIFY_FEATURE = $branchName
+}
+
+if ($Json) {
+    $obj = [PSCustomObject]@{
+        BRANCH_NAME = $branchName
+        FEATURE_NUM = $featureNum
+        HAS_GIT = $hasGit
+    }
+    if ($DryRun) {
+        $obj | Add-Member -NotePropertyName 'DRY_RUN' -NotePropertyValue $true
+    }
+    $obj | ConvertTo-Json -Compress
+} else {
+    Write-Output "BRANCH_NAME: $branchName"
+    Write-Output "FEATURE_NUM: $featureNum"
+    Write-Output "HAS_GIT: $hasGit"
+    if (-not $DryRun) {
+        Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
+    }
+}

--- a/.specify/extensions/git/scripts/powershell/git-common.ps1
+++ b/.specify/extensions/git/scripts/powershell/git-common.ps1
@@ -1,0 +1,51 @@
+#!/usr/bin/env pwsh
+# Git-specific common functions for the git extension.
+# Extracted from scripts/powershell/common.ps1 — contains only git-specific
+# branch validation and detection logic.
+
+function Test-HasGit {
+    param([string]$RepoRoot = (Get-Location))
+    try {
+        if (-not (Test-Path (Join-Path $RepoRoot '.git'))) { return $false }
+        if (-not (Get-Command git -ErrorAction SilentlyContinue)) { return $false }
+        git -C $RepoRoot rev-parse --is-inside-work-tree 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-SpecKitEffectiveBranchName {
+    param([string]$Branch)
+    if ($Branch -match '^([^/]+)/([^/]+)$') {
+        return $Matches[2]
+    }
+    return $Branch
+}
+
+function Test-FeatureBranch {
+    param(
+        [string]$Branch,
+        [bool]$HasGit = $true
+    )
+
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if (-not $HasGit) {
+        Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
+        return $true
+    }
+
+    $raw = $Branch
+    $Branch = Get-SpecKitEffectiveBranchName $raw
+
+    # Accept sequential prefix (3+ digits) but exclude malformed timestamps
+    # Malformed: 7-or-8 digit date + 6-digit time with no trailing slug (e.g. "2026031-143022" or "20260319-143022")
+    $hasMalformedTimestamp = ($Branch -match '^[0-9]{7}-[0-9]{6}-') -or ($Branch -match '^(?:\d{7}|\d{8})-\d{6}$')
+    $isSequential = ($Branch -match '^[0-9]{3,}-') -and (-not $hasMalformedTimestamp)
+    if (-not $isSequential -and $Branch -notmatch '^\d{8}-\d{6}-') {
+        [Console]::Error.WriteLine("ERROR: Not on a feature branch. Current branch: $raw")
+        [Console]::Error.WriteLine("Feature branches should be named like: 001-feature-name, 1234-feature-name, or 20260319-143022-feature-name")
+        return $false
+    }
+    return $true
+}

--- a/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
+++ b/.specify/extensions/git/scripts/powershell/initialize-repo.ps1
@@ -1,0 +1,69 @@
+#!/usr/bin/env pwsh
+# Git extension: initialize-repo.ps1
+# Initialize a Git repository with an initial commit.
+# Customizable — replace this script to add .gitignore templates,
+# default branch config, git-flow, LFS, signing, etc.
+$ErrorActionPreference = 'Stop'
+
+# Find project root
+function Find-ProjectRoot {
+    param([string]$StartDir)
+    $current = Resolve-Path $StartDir
+    while ($true) {
+        foreach ($marker in @('.specify', '.git')) {
+            if (Test-Path (Join-Path $current $marker)) {
+                return $current
+            }
+        }
+        $parent = Split-Path $current -Parent
+        if ($parent -eq $current) { return $null }
+        $current = $parent
+    }
+}
+
+$repoRoot = Find-ProjectRoot -StartDir $PSScriptRoot
+if (-not $repoRoot) { $repoRoot = Get-Location }
+Set-Location $repoRoot
+
+# Read commit message from extension config, fall back to default
+$commitMsg = "[Spec Kit] Initial commit"
+$configFile = Join-Path $repoRoot ".specify/extensions/git/git-config.yml"
+if (Test-Path $configFile) {
+    foreach ($line in Get-Content $configFile) {
+        if ($line -match '^init_commit_message:\s*(.+)$') {
+            $val = $matches[1].Trim() -replace '^["'']' -replace '["'']$'
+            if ($val) { $commitMsg = $val }
+            break
+        }
+    }
+}
+
+# Check if git is available
+if (-not (Get-Command git -ErrorAction SilentlyContinue)) {
+    Write-Warning "[specify] Warning: Git not found; skipped repository initialization"
+    exit 0
+}
+
+# Check if already a git repo
+try {
+    git rev-parse --is-inside-work-tree 2>$null | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Warning "[specify] Git repository already initialized; skipping"
+        exit 0
+    }
+} catch { }
+
+# Initialize
+try {
+    $out = git init -q 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git init failed: $out" }
+    $out = git add . 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git add failed: $out" }
+    $out = git commit --allow-empty -q -m $commitMsg 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "git commit failed: $out" }
+} catch {
+    Write-Warning "[specify] Error: $_"
+    exit 1
+}
+
+Write-Host "✓ Git repository initialized"

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/010-codex-support"
+}

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,10 @@
+{
+  "ai": "opencode",
+  "branch_numbering": "sequential",
+  "context_file": "AGENTS.md",
+  "here": true,
+  "integration": "opencode",
+  "preset": null,
+  "script": "ps",
+  "speckit_version": "0.7.4.dev0"
+}

--- a/.specify/integration.json
+++ b/.specify/integration.json
@@ -1,0 +1,4 @@
+{
+  "integration": "opencode",
+  "version": "0.7.4.dev0"
+}

--- a/.specify/integrations/codex.manifest.json
+++ b/.specify/integrations/codex.manifest.json
@@ -1,0 +1,16 @@
+{
+  "integration": "codex",
+  "version": "0.7.4.dev0",
+  "installed_at": "2026-04-18T14:01:32.862311+00:00",
+  "files": {
+    ".agents/skills/speckit-analyze/SKILL.md": "a6cce8cacc71572a60a2a81d6e9de778fd948ac4353b7be2ab6bc392b6a27625",
+    ".agents/skills/speckit-checklist/SKILL.md": "9a71567ee76ebd332139d33c8a70d9d1925079f2e2b3469ce1729582ef59f278",
+    ".agents/skills/speckit-clarify/SKILL.md": "3d3889843d4ad95021d9ba2e16e8107a57bf72ccc576a6dbafad41a96e290015",
+    ".agents/skills/speckit-constitution/SKILL.md": "7310adee465ee6a439a689518e6c133ce851d808c7a6e64d66f659ad8b4bd56e",
+    ".agents/skills/speckit-implement/SKILL.md": "24eb9c9293bb867302bce76a37186c465703ff4e18b3c9096e5bb6291da6cb10",
+    ".agents/skills/speckit-plan/SKILL.md": "8f23b270185a63a10e1c7b9c477e867c3115a6195e67528f4b3f3f40b9a99bec",
+    ".agents/skills/speckit-specify/SKILL.md": "019e30edd3f31267b48a9c846311ac07e78661b7599d3a96e94bded5b8f646fe",
+    ".agents/skills/speckit-tasks/SKILL.md": "3ae247890607630c61558c153d10858f37e1b7ce8aaefe9e486fd4b41980b600",
+    ".agents/skills/speckit-taskstoissues/SKILL.md": "93cacb7c23e4cb4e1c954ac6681389be8a3862f4eb22f9f710de8299a219aadf"
+  }
+}

--- a/.specify/integrations/opencode.manifest.json
+++ b/.specify/integrations/opencode.manifest.json
@@ -1,0 +1,16 @@
+{
+  "integration": "opencode",
+  "version": "0.7.4.dev0",
+  "installed_at": "2026-04-18T14:02:10.581986+00:00",
+  "files": {
+    ".opencode/command/speckit.analyze.md": "56285817b93f55ae926eade0528673d25ffcf441e8109492323bfbe8941be8f7",
+    ".opencode/command/speckit.checklist.md": "53ce35462c1df402780e730ea54150a30872e6e0d6d44a8bd38dd8b5d42900a9",
+    ".opencode/command/speckit.clarify.md": "97b14836d6174f0ef51d8bbda0b731c87ef0b011aa36ccd4171a2fc3d7e3280a",
+    ".opencode/command/speckit.constitution.md": "58d35eb026f56bb7364d91b8b0382d5dd1249ded6c1449a2b69546693afb85f7",
+    ".opencode/command/speckit.implement.md": "9dda40376414146a8992d09e6853976c75708ba4cad7d9df9fcd6e7faa8f0a4c",
+    ".opencode/command/speckit.plan.md": "b9534d77d040b2ec242e8c60718f52b6ad32b736aecd8970b993449ccc8d35e8",
+    ".opencode/command/speckit.specify.md": "5bbb5270836cc9a3286ce3ed96a500f3d383a54abb06aa11b01a2d2f76dbf39b",
+    ".opencode/command/speckit.tasks.md": "d505523168e1f1c758350da9d45c08ff990ed8686d6bc8451db8b89a145768a4",
+    ".opencode/command/speckit.taskstoissues.md": "12532e50c8f9aeb453a565aec6aa6f53abe53cf92926ca553b3d2c61b6b7b6e3"
+  }
+}

--- a/.specify/integrations/speckit.manifest.json
+++ b/.specify/integrations/speckit.manifest.json
@@ -1,0 +1,6 @@
+{
+  "integration": "speckit",
+  "version": "0.7.4.dev0",
+  "installed_at": "2026-04-18T14:02:10.597629+00:00",
+  "files": {}
+}

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -1,0 +1,63 @@
+schema_version: "1.0"
+workflow:
+  id: "speckit"
+  name: "Full SDD Cycle"
+  version: "1.0.0"
+  author: "GitHub"
+  description: "Runs specify → plan → tasks → implement with review gates"
+
+requires:
+  speckit_version: ">=0.7.2"
+  integrations:
+    any: ["copilot", "claude", "gemini"]
+
+inputs:
+  spec:
+    type: string
+    required: true
+    prompt: "Describe what you want to build"
+  integration:
+    type: string
+    default: "copilot"
+    prompt: "Integration to use (e.g. claude, copilot, gemini)"
+  scope:
+    type: string
+    default: "full"
+    enum: ["full", "backend-only", "frontend-only"]
+
+steps:
+  - id: specify
+    command: speckit.specify
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-spec
+    type: gate
+    message: "Review the generated spec before planning."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: plan
+    command: speckit.plan
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: review-plan
+    type: gate
+    message: "Review the plan before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: tasks
+    command: speckit.tasks
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: implement
+    command: speckit.implement
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"

--- a/.specify/workflows/workflow-registry.json
+++ b/.specify/workflows/workflow-registry.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0",
+  "workflows": {
+    "speckit": {
+      "name": "Full SDD Cycle",
+      "version": "1.0.0",
+      "description": "Runs specify \u2192 plan \u2192 tasks \u2192 implement with review gates",
+      "source": "bundled",
+      "installed_at": "2026-04-18T14:01:02.804980+00:00",
+      "updated_at": "2026-04-18T14:01:02.804992+00:00"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+<!-- SPECKIT START -->
+For additional context about technologies to be used, project structure,
+shell commands, and other important information, read the current plan
+<!-- SPECKIT END -->

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ ralph build
 ralph
 ```
 
-That's it. Ralph reads your spec, drives Claude through iterations, commits results, and the Regent supervises the whole thing.
+That's it. Ralph reads your spec, drives the selected agent through iterations, commits results, and the Regent supervises the whole thing.
 
 ---
 
@@ -302,10 +302,16 @@ Place `ralph.toml` in your project root. All fields are optional with sensible d
 [project]
 name = "MyProject"
 
+[agent]
+type = "claude"               # claude or codex
+
 [claude]
 model = "sonnet"              # Claude model to use
 max_turns = 0                 # 0 = unlimited agentic turns per iteration
 danger_skip_permissions = true
+
+[codex]
+model = ""                    # optional Codex model override
 
 [plan]
 prompt_file = "PLAN.md"       # prompt template for plan iterations
@@ -486,7 +492,7 @@ ralph build -w --no-tui --max 5
 | Agent | Status | Description |
 |-------|:------:|-------------|
 | 🤖 Claude Code CLI | ✅ | Default — streaming JSON event parser, full integration |
-| 🔮 OpenAI Codex | 🔜 | Planned |
+| 🔮 OpenAI Codex | ✅ | Opt-in for supported single-run `build`, `loop build`, `loop plan`, and `loop run` flows |
 | 💎 Gemini | 🔜 | Planned |
 | 🔧 Custom | 🔜 | Bring your own agent via adapter interface |
 

--- a/cmd/ralph/commands.go
+++ b/cmd/ralph/commands.go
@@ -12,11 +12,11 @@ import (
 	"github.com/LISSConsulting/RalphSpec/internal/spec"
 )
 
-// loopCmd returns the parent command for autonomous Claude loop commands.
+// loopCmd returns the parent command for autonomous agent loop commands.
 func loopCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "loop",
-		Short: "Autonomous Claude loop commands",
+		Short: "Autonomous agent loop commands",
 	}
 	cmd.AddCommand(loopPlanCmd(), loopBuildCmd(), loopRunCmd())
 	return cmd
@@ -25,16 +25,18 @@ func loopCmd() *cobra.Command {
 func loopPlanCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "plan",
-		Short: "Run Claude in plan mode",
+		Short: "Run an agent in plan mode",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			max, _ := cmd.Flags().GetInt("max")
+			agent, _ := cmd.Flags().GetString("agent")
 			noTUI, _ := cmd.Root().PersistentFlags().GetBool("no-tui")
 			noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
 			worktreeFlag, _ := cmd.Flags().GetBool("worktree")
-			return executeLoop(loop.ModePlan, max, noTUI, false, "", noColor, worktreeFlag)
+			return executeLoop(loop.ModePlan, max, noTUI, false, "", noColor, worktreeFlag, agent)
 		},
 	}
 	cmd.Flags().Int("max", 0, "override max iterations (0 = use config)")
+	cmd.Flags().String("agent", "", "override agent for this run (claude or codex)")
 	cmd.Flags().BoolP("worktree", "w", false, "run loop in an isolated git worktree via worktrunk")
 	return cmd
 }
@@ -42,18 +44,20 @@ func loopPlanCmd() *cobra.Command {
 func loopBuildCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
-		Short: "Run Claude in build mode",
+		Short: "Run an agent in build mode",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			max, _ := cmd.Flags().GetInt("max")
+			agent, _ := cmd.Flags().GetString("agent")
 			noTUI, _ := cmd.Root().PersistentFlags().GetBool("no-tui")
 			noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
 			roam, _ := cmd.Flags().GetBool("roam")
 			focus, _ := cmd.Flags().GetString("focus")
 			worktreeFlag, _ := cmd.Flags().GetBool("worktree")
-			return executeLoop(loop.ModeBuild, max, noTUI, roam, focus, noColor, worktreeFlag)
+			return executeLoop(loop.ModeBuild, max, noTUI, roam, focus, noColor, worktreeFlag, agent)
 		},
 	}
 	cmd.Flags().Int("max", 0, "override max iterations (0 = use config)")
+	cmd.Flags().String("agent", "", "override agent for this run (claude or codex)")
 	cmd.Flags().Bool("roam", false, "roam freely across the codebase instead of targeting the active spec")
 	cmd.Flags().String("focus", "", "constrain roam to a specific topic (e.g. \"UI/UX\")")
 	cmd.Flags().BoolP("worktree", "w", false, "run loop in an isolated git worktree via worktrunk")
@@ -66,15 +70,17 @@ func loopRunCmd() *cobra.Command {
 		Short: "Smart mode: plan if needed, then build",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			max, _ := cmd.Flags().GetInt("max")
+			agent, _ := cmd.Flags().GetString("agent")
 			noTUI, _ := cmd.Root().PersistentFlags().GetBool("no-tui")
 			noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
 			roam, _ := cmd.Flags().GetBool("roam")
 			focus, _ := cmd.Flags().GetString("focus")
 			worktreeFlag, _ := cmd.Flags().GetBool("worktree")
-			return executeSmartRun(max, noTUI, roam, focus, noColor, worktreeFlag)
+			return executeSmartRun(max, noTUI, roam, focus, noColor, worktreeFlag, agent)
 		},
 	}
 	cmd.Flags().Int("max", 0, "override max iterations (0 = use config)")
+	cmd.Flags().String("agent", "", "override agent for this run (claude or codex)")
 	cmd.Flags().Bool("roam", false, "roam freely across the codebase instead of targeting the active spec")
 	cmd.Flags().String("focus", "", "constrain roam to a specific topic (e.g. \"UI/UX\")")
 	cmd.Flags().BoolP("worktree", "w", false, "run loop in an isolated git worktree via worktrunk")
@@ -85,18 +91,20 @@ func loopRunCmd() *cobra.Command {
 func buildCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "build",
-		Short: "Run Claude in build mode",
+		Short: "Run an agent in build mode",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			max, _ := cmd.Flags().GetInt("max")
+			agent, _ := cmd.Flags().GetString("agent")
 			noTUI, _ := cmd.Root().PersistentFlags().GetBool("no-tui")
 			noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
 			roam, _ := cmd.Flags().GetBool("roam")
 			focus, _ := cmd.Flags().GetString("focus")
 			worktreeFlag, _ := cmd.Flags().GetBool("worktree")
-			return executeLoop(loop.ModeBuild, max, noTUI, roam, focus, noColor, worktreeFlag)
+			return executeLoop(loop.ModeBuild, max, noTUI, roam, focus, noColor, worktreeFlag, agent)
 		},
 	}
 	cmd.Flags().Int("max", 0, "override max iterations (0 = use config)")
+	cmd.Flags().String("agent", "", "override agent for this run (claude or codex)")
 	cmd.Flags().Bool("roam", false, "roam freely across the codebase instead of targeting the active spec")
 	cmd.Flags().String("focus", "", "constrain roam to a specific topic (e.g. \"UI/UX\")")
 	cmd.Flags().BoolP("worktree", "w", false, "run loop in an isolated git worktree via worktrunk")

--- a/cmd/ralph/commands_test.go
+++ b/cmd/ralph/commands_test.go
@@ -317,6 +317,44 @@ func TestLoopCmdsHaveMaxFlag(t *testing.T) {
 	}
 }
 
+func TestLoopCmdsHaveAgentFlag(t *testing.T) {
+	root := rootCmd()
+
+	var loopCmd *cobra.Command
+	for _, sub := range root.Commands() {
+		if sub.Name() == "loop" {
+			loopCmd = sub
+			break
+		}
+	}
+	if loopCmd == nil {
+		t.Fatal("missing loop subcommand")
+	}
+
+	for _, name := range []string{"plan", "build", "run"} {
+		t.Run(name, func(t *testing.T) {
+			for _, sub := range loopCmd.Commands() {
+				if sub.Name() == name {
+					if sub.Flags().Lookup("agent") == nil {
+						t.Errorf("loop %s: missing --agent flag", name)
+					}
+					return
+				}
+			}
+			t.Fatalf("loop subcommand %q not found", name)
+		})
+	}
+
+	for _, sub := range root.Commands() {
+		if sub.Name() == "build" {
+			if sub.Flags().Lookup("agent") == nil {
+				t.Error("top-level build: missing --agent flag")
+			}
+			return
+		}
+	}
+}
+
 func TestSpecCmdSubcommands(t *testing.T) {
 	root := rootCmd()
 

--- a/cmd/ralph/execute.go
+++ b/cmd/ralph/execute.go
@@ -321,7 +321,11 @@ func showStatus() error {
 // formatStatus renders a Regent state snapshot as a human-readable status
 // string. The now parameter pins the current time for deterministic output.
 func formatStatus(state regent.State, now time.Time) string {
-	result := classifyResult(state)
+	return formatStatusWithPIDCheck(state, now, processExists)
+}
+
+func formatStatusWithPIDCheck(state regent.State, now time.Time, pidRunning func(int) bool) string {
+	result := classifyResultWithPIDCheck(state, pidRunning)
 	if result == statusNoState {
 		return "No state found. Run 'ralph build' or 'ralph run' first.\n"
 	}
@@ -348,6 +352,9 @@ func formatStatus(state regent.State, now time.Time) string {
 	if result == statusRunning {
 		elapsed := now.Sub(state.StartedAt).Round(time.Second)
 		fmt.Fprintf(&b, "  %-20s %s (running)\n", "Duration:", elapsed)
+	} else if !state.StartedAt.IsZero() && state.FinishedAt.IsZero() {
+		elapsed := now.Sub(state.StartedAt).Round(time.Second)
+		fmt.Fprintf(&b, "  %-20s %s\n", "Duration:", elapsed)
 	} else if !state.StartedAt.IsZero() && !state.FinishedAt.IsZero() {
 		dur := state.FinishedAt.Sub(state.StartedAt).Round(time.Second)
 		fmt.Fprintf(&b, "  %-20s %s\n", "Duration:", dur)
@@ -423,13 +430,23 @@ const (
 // classifyResult determines the result label from a Regent state snapshot.
 // The priority order is: no-state, running, pass, fail-with-errors, plain-fail.
 func classifyResult(state regent.State) statusResult {
+	return classifyResultWithPIDCheck(state, processExists)
+}
+
+func classifyResultWithPIDCheck(state regent.State, pidRunning func(int) bool) statusResult {
 	if state.RalphPID == 0 && state.Iteration == 0 {
 		return statusNoState
 	}
 	running := !state.StartedAt.IsZero() && state.FinishedAt.IsZero()
 	switch {
-	case running:
+	case running && pidRunning(state.RalphPID):
 		return statusRunning
+	case state.Passed:
+		return statusPass
+	case state.ConsecutiveErrs > 0:
+		return statusFailWithErrors
+	case running:
+		return statusFail
 	case state.Passed:
 		return statusPass
 	case state.ConsecutiveErrs > 0:

--- a/cmd/ralph/execute.go
+++ b/cmd/ralph/execute.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/LISSConsulting/RalphSpec/internal/claude"
+	"github.com/LISSConsulting/RalphSpec/internal/codex"
 	"github.com/LISSConsulting/RalphSpec/internal/config"
 	"github.com/LISSConsulting/RalphSpec/internal/git"
 	"github.com/LISSConsulting/RalphSpec/internal/loop"
@@ -34,12 +36,13 @@ type loopSetup struct {
 	sr            store.Reader
 	formatter     lineFormatter
 	cleanup       func() // closes the JSONL store if one was opened
+	agentType     string
 }
 
 // setupLoop performs the common initialisation shared by executeLoop and
 // executeSmartRun: config load, validation, working dir, signal context, git
 // runner, loop struct init, spec resolution, and store init.
-func setupLoop(noTUI, roam, noColor bool) (*loopSetup, error) {
+func setupLoop(noTUI, roam, noColor bool, agentOverride string) (*loopSetup, error) {
 	cfg, err := config.Load("")
 	if err != nil {
 		return nil, err
@@ -64,12 +67,21 @@ func setupLoop(noTUI, roam, noColor bool) (*loopSetup, error) {
 
 	gitRunner := git.NewRunner(dir)
 	effectiveRoam := roam || cfg.Build.Roam
+	agentType, err := resolveAgent(cfg, agentOverride)
+	if err != nil {
+		return nil, fmt.Errorf("config validation: %w", err)
+	}
+	agentImpl, err := buildAgent(agentType)
+	if err != nil {
+		return nil, err
+	}
 
 	lp := &loop.Loop{
-		Agent:  loop.NewClaudeAgent(),
-		Git:    gitRunner,
-		Config: cfg,
-		Dir:    dir,
+		Agent:     agentImpl,
+		AgentType: agentType,
+		Git:       gitRunner,
+		Config:    cfg,
+		Dir:       dir,
 	}
 	if stopCh != nil {
 		lp.StopAfter = stopCh
@@ -116,17 +128,22 @@ func setupLoop(noTUI, roam, noColor bool) (*loopSetup, error) {
 		sr:            sr,
 		formatter:     lineFormatter{color: !noColor},
 		cleanup:       cleanup,
+		agentType:     agentType,
 	}, nil
 }
 
 // executeLoop loads config, builds the loop, and runs it in the given mode.
-func executeLoop(mode loop.Mode, maxOverride int, noTUI bool, roam bool, focus string, noColor bool, useWorktree bool) error {
-	setup, err := setupLoop(noTUI, roam, noColor)
+func executeLoop(mode loop.Mode, maxOverride int, noTUI bool, roam bool, focus string, noColor bool, useWorktree bool, agentOverride string) error {
+	setup, err := setupLoop(noTUI, roam, noColor, agentOverride)
 	if err != nil {
 		return err
 	}
 	defer setup.cancel()
 	defer setup.cleanup()
+
+	if err := validateAgentFlow(setup.agentType, useWorktree, false); err != nil {
+		return err
+	}
 
 	// Worktree mode: create an isolated worktree and run the loop inside it.
 	if useWorktree {
@@ -233,13 +250,17 @@ func setupWorktree(setup *loopSetup) error {
 }
 
 // executeSmartRun runs plan if CHRONICLE.md doesn't exist, then build.
-func executeSmartRun(maxOverride int, noTUI bool, roam bool, focus string, noColor bool, useWorktree bool) error {
-	setup, err := setupLoop(noTUI, roam, noColor)
+func executeSmartRun(maxOverride int, noTUI bool, roam bool, focus string, noColor bool, useWorktree bool, agentOverride string) error {
+	setup, err := setupLoop(noTUI, roam, noColor, agentOverride)
 	if err != nil {
 		return err
 	}
 	defer setup.cancel()
 	defer setup.cleanup()
+
+	if err := validateAgentFlow(setup.agentType, useWorktree, false); err != nil {
+		return err
+	}
 
 	if useWorktree {
 		if wtErr := setupWorktree(setup); wtErr != nil {
@@ -312,6 +333,9 @@ func formatStatus(state regent.State, now time.Time) string {
 	if state.Branch != "" {
 		fmt.Fprintf(&b, "  %-20s %s\n", "Branch:", state.Branch)
 	}
+	if state.Agent != "" {
+		fmt.Fprintf(&b, "  %-20s %s\n", "Agent:", state.Agent)
+	}
 	if state.Mode != "" {
 		fmt.Fprintf(&b, "  %-20s %s\n", "Mode:", state.Mode)
 	}
@@ -346,6 +370,43 @@ func formatStatus(state regent.State, now time.Time) string {
 	}
 
 	return b.String()
+}
+
+func resolveAgent(cfg *config.Config, override string) (string, error) {
+	agentType := cfg.Agent.Type
+	if override != "" {
+		agentType = override
+	}
+	if agentType == "" {
+		agentType = config.AgentClaude
+	}
+	if agentType != config.AgentClaude && agentType != config.AgentCodex {
+		return "", fmt.Errorf("agent.type must be one of %s,%s", config.AgentClaude, config.AgentCodex)
+	}
+	return agentType, nil
+}
+
+func buildAgent(agentType string) (claude.Agent, error) {
+	if agentType == config.AgentCodex {
+		if err := codex.CheckAvailable(""); err != nil {
+			return nil, fmt.Errorf("codex agent unavailable: %w; install or log into Codex CLI, or use --agent claude", err)
+		}
+		return codex.NewAgent(), nil
+	}
+	return loop.NewClaudeAgent(), nil
+}
+
+func validateAgentFlow(agentType string, useWorktree bool, dashboard bool) error {
+	if agentType != config.AgentCodex {
+		return nil
+	}
+	if useWorktree {
+		return fmt.Errorf("codex agent unsupported for worktree mode; use --agent claude or omit --worktree")
+	}
+	if dashboard {
+		return fmt.Errorf("codex agent unsupported for dashboard mode; start Codex with ralph build --agent codex --no-tui or use claude in the dashboard")
+	}
+	return nil
 }
 
 // statusResult represents the outcome classification for ralph status display.

--- a/cmd/ralph/execute.go
+++ b/cmd/ralph/execute.go
@@ -321,11 +321,16 @@ func showStatus() error {
 // formatStatus renders a Regent state snapshot as a human-readable status
 // string. The now parameter pins the current time for deterministic output.
 func formatStatus(state regent.State, now time.Time) string {
-	return formatStatusWithPIDCheck(state, now, processExists)
+	result := classifyResult(state)
+	return formatStatusWithResult(state, now, result)
 }
 
 func formatStatusWithPIDCheck(state regent.State, now time.Time, pidRunning func(int) bool) string {
 	result := classifyResultWithPIDCheck(state, pidRunning)
+	return formatStatusWithResult(state, now, result)
+}
+
+func formatStatusWithResult(state regent.State, now time.Time, result statusResult) string {
 	if result == statusNoState {
 		return "No state found. Run 'ralph build' or 'ralph run' first.\n"
 	}
@@ -349,13 +354,14 @@ func formatStatusWithPIDCheck(state regent.State, now time.Time, pidRunning func
 	fmt.Fprintf(&b, "  %-20s %d\n", "Iteration:", state.Iteration)
 	fmt.Fprintf(&b, "  %-20s $%.2f\n", "Total cost:", state.TotalCostUSD)
 
-	if result == statusRunning {
+	switch {
+	case result == statusRunning:
 		elapsed := now.Sub(state.StartedAt).Round(time.Second)
 		fmt.Fprintf(&b, "  %-20s %s (running)\n", "Duration:", elapsed)
-	} else if !state.StartedAt.IsZero() && state.FinishedAt.IsZero() {
+	case !state.StartedAt.IsZero() && state.FinishedAt.IsZero():
 		elapsed := now.Sub(state.StartedAt).Round(time.Second)
 		fmt.Fprintf(&b, "  %-20s %s\n", "Duration:", elapsed)
-	} else if !state.StartedAt.IsZero() && !state.FinishedAt.IsZero() {
+	case !state.StartedAt.IsZero() && !state.FinishedAt.IsZero():
 		dur := state.FinishedAt.Sub(state.StartedAt).Round(time.Second)
 		fmt.Fprintf(&b, "  %-20s %s\n", "Duration:", dur)
 	}
@@ -441,9 +447,7 @@ func classifyResultWithPIDCheck(state regent.State, pidRunning func(int) bool) s
 	switch {
 	case running && pidRunning(state.RalphPID):
 		return statusRunning
-	case state.Passed:
-		return statusPass
-	case state.ConsecutiveErrs > 0:
+	case running && state.ConsecutiveErrs > 0:
 		return statusFailWithErrors
 	case running:
 		return statusFail

--- a/cmd/ralph/execute_test.go
+++ b/cmd/ralph/execute_test.go
@@ -44,6 +44,15 @@ func TestClassifyResult(t *testing.T) {
 			want: statusRunning,
 		},
 		{
+			name: "stale unfinished state becomes fail",
+			state: regent.State{
+				RalphPID:  123,
+				Iteration: 3,
+				StartedAt: past,
+			},
+			want: statusFail,
+		},
+		{
 			name: "pass — finished with Passed true",
 			state: regent.State{
 				RalphPID:   123,
@@ -115,7 +124,10 @@ func TestClassifyResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyResult(tt.state)
+			pidRunning := func(pid int) bool {
+				return (tt.name == "running — started but not finished" || tt.name == "running wins over passed") && pid == 123
+			}
+			got := classifyResultWithPIDCheck(tt.state, pidRunning)
 			if got != tt.want {
 				t.Errorf("classifyResult() = %d, want %d", got, tt.want)
 			}
@@ -229,6 +241,26 @@ func TestFormatStatus(t *testing.T) {
 			},
 		},
 		{
+			name: "stale unfinished state shows fail not running",
+			state: regent.State{
+				RalphPID:     999999,
+				Iteration:    3,
+				Branch:       "feat/test",
+				Mode:         "build",
+				TotalCostUSD: 0.42,
+				StartedAt:    started,
+				LastOutputAt: lastOutput,
+			},
+			contains: []string{
+				"Ralph Status",
+				"Duration:",
+				"10m0s",
+				"Result:",
+				"fail",
+			},
+			excludes: []string{"(running)", "Last output:", "running"},
+		},
+		{
 			name: "pass — shows duration and pass result",
 			state: regent.State{
 				RalphPID:     123,
@@ -316,7 +348,10 @@ func TestFormatStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatStatus(tt.state, now)
+			pidRunning := func(pid int) bool {
+				return (tt.name == "running — shows elapsed duration and last output" || tt.name == "running without last output — omits last output line") && pid == 123
+			}
+			got := formatStatusWithPIDCheck(tt.state, now, pidRunning)
 			for _, want := range tt.contains {
 				if !strings.Contains(got, want) {
 					t.Errorf("output should contain %q\ngot:\n%s", want, got)

--- a/cmd/ralph/execute_test.go
+++ b/cmd/ralph/execute_test.go
@@ -1,16 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/LISSConsulting/RalphSpec/internal/config"
 	"github.com/LISSConsulting/RalphSpec/internal/loop"
 	"github.com/LISSConsulting/RalphSpec/internal/regent"
 )
@@ -197,6 +200,7 @@ func TestFormatStatus(t *testing.T) {
 			name: "running — shows elapsed duration and last output",
 			state: regent.State{
 				RalphPID:     123,
+				Agent:        "codex",
 				Iteration:    3,
 				Branch:       "feat/test",
 				Mode:         "build",
@@ -209,6 +213,8 @@ func TestFormatStatus(t *testing.T) {
 				"Ralph Status",
 				"Branch:",
 				"feat/test",
+				"Agent:",
+				"codex",
 				"Mode:",
 				"build",
 				"Last commit:",
@@ -325,6 +331,202 @@ func TestFormatStatus(t *testing.T) {
 	}
 }
 
+func TestResolveAgent(t *testing.T) {
+	cfg := &config.Config{Agent: config.AgentConfig{Type: config.AgentCodex}}
+
+	got, err := resolveAgent(cfg, config.AgentClaude)
+	if err != nil {
+		t.Fatalf("resolveAgent override error: %v", err)
+	}
+	if got != config.AgentClaude {
+		t.Fatalf("override got %q, want %q", got, config.AgentClaude)
+	}
+
+	got, err = resolveAgent(&config.Config{}, "")
+	if err != nil {
+		t.Fatalf("resolveAgent default error: %v", err)
+	}
+	if got != config.AgentClaude {
+		t.Fatalf("default got %q, want %q", got, config.AgentClaude)
+	}
+
+	if _, err := resolveAgent(&config.Config{}, "nope"); err == nil {
+		t.Fatal("expected unknown-agent error")
+	}
+}
+
+func TestValidateAgentFlow(t *testing.T) {
+	if err := validateAgentFlow(config.AgentCodex, true, false); err == nil {
+		t.Fatal("expected worktree rejection for codex")
+	}
+	if err := validateAgentFlow(config.AgentCodex, false, true); err == nil {
+		t.Fatal("expected dashboard rejection for codex")
+	}
+	if err := validateAgentFlow(config.AgentClaude, true, true); err != nil {
+		t.Fatalf("claude should remain supported, got %v", err)
+	}
+}
+
+func TestSetupLoop_AgentPrecedence(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", `[agent]
+type = "codex"
+
+[plan]
+prompt_file = "PLAN.md"
+max_iterations = 1
+
+[build]
+prompt_file = "BUILD.md"
+max_iterations = 1
+
+[git]
+auto_pull_rebase = false
+auto_push = false
+
+[regent]
+enabled = false
+`)
+	writeFakeCodexRunner(t, dir, `{"type":"result","cost_usd":0.01,"duration_ms":1,"subtype":"success"}`, "", 0)
+	prependCLIPath(t, dir)
+
+	setup, err := setupLoop(true, false, true, "")
+	if err != nil {
+		t.Fatalf("setupLoop default agent: %v", err)
+	}
+	defer setup.cancel()
+	defer setup.cleanup()
+	if setup.agentType != config.AgentCodex {
+		t.Fatalf("default setup agent = %q, want %q", setup.agentType, config.AgentCodex)
+	}
+
+	setup2, err := setupLoop(true, false, true, config.AgentClaude)
+	if err != nil {
+		t.Fatalf("setupLoop override agent: %v", err)
+	}
+	defer setup2.cancel()
+	defer setup2.cleanup()
+	if setup2.agentType != config.AgentClaude {
+		t.Fatalf("override setup agent = %q, want %q", setup2.agentType, config.AgentClaude)
+	}
+}
+
+func TestExecuteLoop_CodexUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
+	t.Setenv("PATH", "")
+
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, config.AgentCodex)
+	if err == nil {
+		t.Fatal("expected codex unavailable error")
+	}
+	if !strings.Contains(err.Error(), "codex agent unavailable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "use --agent claude") {
+		t.Fatalf("expected actionable guidance, got: %v", err)
+	}
+}
+
+func TestExecuteLoop_CodexWorktreeUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
+	writeFakeCLIExecutable(t, dir, "codex")
+	prependCLIPath(t, dir)
+
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, true, config.AgentCodex)
+	if err == nil {
+		t.Fatal("expected unsupported-worktree error")
+	}
+	if !strings.Contains(err.Error(), "codex agent unsupported for worktree mode") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "omit --worktree") {
+		t.Fatalf("expected actionable guidance, got: %v", err)
+	}
+}
+
+func TestExecuteLoop_CodexPlanSuccess(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
+	writeExecTestFile(t, dir, "PLAN.md", "# Plan\n")
+	writeExecTestFile(t, dir, "BUILD.md", "# Build\n")
+	writeFakeCodexRunner(t, dir, strings.Join([]string{
+		`{"type":"message","text":"planning"}`,
+		`{"type":"result","cost_usd":0.10,"duration_ms":25,"subtype":"success"}`,
+	}, "\n"), "", 0)
+	prependCLIPath(t, dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := executeLoop(loop.ModePlan, 1, true, false, "", true, false, config.AgentCodex)
+	_ = w.Close()
+	os.Stdout = oldStdout
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	if err != nil {
+		t.Fatalf("expected successful codex plan run, got %v", err)
+	}
+	if !strings.Contains(buf.String(), "[codex]") {
+		t.Fatalf("expected live output to contain codex prefix, got %q", buf.String())
+	}
+	state, loadErr := regent.LoadState(dir)
+	if loadErr != nil {
+		t.Fatalf("LoadState: %v", loadErr)
+	}
+	if state.Agent != config.AgentCodex {
+		t.Fatalf("state.Agent = %q, want %q", state.Agent, config.AgentCodex)
+	}
+}
+
+func TestExecuteSmartRun_CodexBuildSuccess(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", `[agent]
+type = "codex"
+`+testConfigNoRegent())
+	writeExecTestFile(t, dir, "CHRONICLE.md", "# Chronicle\n\nready\n")
+	writeExecTestFile(t, dir, "BUILD.md", "# Build\n")
+	writeFakeCodexRunner(t, dir, `{"type":"result","cost_usd":0.10,"duration_ms":25,"subtype":"success"}`, "", 0)
+	prependCLIPath(t, dir)
+
+	err := executeSmartRun(1, true, false, "", true, false, "")
+	if err != nil {
+		t.Fatalf("expected successful smart codex run, got %v", err)
+	}
+	state, loadErr := regent.LoadState(dir)
+	if loadErr != nil {
+		t.Fatalf("LoadState: %v", loadErr)
+	}
+	if state.Agent != config.AgentCodex {
+		t.Fatalf("state.Agent = %q, want %q", state.Agent, config.AgentCodex)
+	}
+}
+
+func TestExecuteLoop_DefaultClaudeRegression(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
+
+	setup, err := setupLoop(true, false, true, "")
+	if err != nil {
+		t.Fatalf("setupLoop: %v", err)
+	}
+	defer setup.cancel()
+	defer setup.cleanup()
+	if setup.agentType != config.AgentClaude {
+		t.Fatalf("default agent = %q, want %q", setup.agentType, config.AgentClaude)
+	}
+}
+
 // ---- Integration tests for executeLoop and executeSmartRun ----
 //
 // These tests exercise the full orchestration path through config loading,
@@ -388,11 +590,63 @@ func writeExecTestFile(t *testing.T, dir, name, content string) {
 	}
 }
 
+func writeFakeCLIExecutable(t *testing.T, dir, base string) string {
+	t.Helper()
+	name := base
+	content := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name += ".cmd"
+		content = "@echo off\r\nexit /b 0\r\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("WriteFile %s: %v", name, err)
+	}
+	return name
+}
+
+func writeFakeCodexRunner(t *testing.T, dir, stdout, stderr string, exitCode int) {
+	t.Helper()
+	stdoutPath := filepath.Join(dir, "codex-stdout.txt")
+	if err := os.WriteFile(stdoutPath, []byte(stdout), 0644); err != nil {
+		t.Fatalf("WriteFile codex stdout: %v", err)
+	}
+	stderrPath := filepath.Join(dir, "codex-stderr.txt")
+	if err := os.WriteFile(stderrPath, []byte(stderr), 0644); err != nil {
+		t.Fatalf("WriteFile codex stderr: %v", err)
+	}
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\ntype \"%~dp0codex-stdout.txt\"\r\ntype \"%~dp0codex-stderr.txt\" 1>&2\r\nexit /b " + strconv.Itoa(exitCode) + "\r\n"
+		if err := os.WriteFile(filepath.Join(dir, "codex.cmd"), []byte(script), 0755); err != nil {
+			t.Fatalf("WriteFile codex.cmd: %v", err)
+		}
+		return
+	}
+	script := "#!/bin/sh\ncat \"$(dirname \"$0\")/codex-stdout.txt\"\nif [ -s \"$(dirname \"$0\")/codex-stderr.txt\" ]; then cat \"$(dirname \"$0\")/codex-stderr.txt\" >&2; fi\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "codex"), []byte(script), 0755); err != nil {
+		t.Fatalf("WriteFile codex: %v", err)
+	}
+}
+
+func prependCLIPath(t *testing.T, dir string) {
+	t.Helper()
+	oldPath := os.Getenv("PATH")
+	sep := ":"
+	if runtime.GOOS == "windows" {
+		sep = ";"
+	}
+	if oldPath == "" {
+		t.Setenv("PATH", dir)
+		return
+	}
+	t.Setenv("PATH", dir+sep+oldPath)
+}
+
 func TestExecuteLoop_ConfigNotFound(t *testing.T) {
 	// Isolated temp dir with no ralph.toml anywhere in its ancestor tree.
 	t.Chdir(t.TempDir())
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when ralph.toml not found")
 	}
@@ -407,7 +661,7 @@ func TestExecuteLoop_ConfigInvalid(t *testing.T) {
 	// Empty plan.prompt_file fails Validate()
 	writeExecTestFile(t, dir, "ralph.toml", "[plan]\nprompt_file = \"\"\n[build]\nprompt_file = \"b.md\"\n")
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -423,7 +677,7 @@ func TestExecuteLoop_RegentDisabled_PromptMissing(t *testing.T) {
 	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
 	// PLAN.md intentionally absent — loop.Run fails reading it.
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when prompt file missing")
 	}
@@ -440,7 +694,7 @@ func TestExecuteLoop_RegentEnabled_PromptMissing(t *testing.T) {
 	// PLAN.md intentionally absent.
 	// Pre-flight check returns an error before Regent is initialised.
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when prompt file missing")
 	}
@@ -456,7 +710,7 @@ func TestExecuteLoop_BuildMode_PromptMissing(t *testing.T) {
 	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
 	// BUILD.md intentionally absent — covers default case in mode switch.
 
-	err := executeLoop(loop.ModeBuild, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModeBuild, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when build prompt file missing")
 	}
@@ -474,7 +728,7 @@ func TestExecuteLoop_RegentDisabled_PromptExists_GitFails(t *testing.T) {
 	writeExecTestFile(t, dir, "ralph.toml", testConfigNoRegent())
 	writeExecTestFile(t, dir, "PLAN.md", "# Plan\n")
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	// Loop fails at git CurrentBranch — must be an error but not a prompt-file error.
 	if err == nil {
 		t.Fatal("expected error from git operations")
@@ -494,7 +748,7 @@ func TestExecuteLoop_RegentEnabled_PromptExists_GitFails(t *testing.T) {
 	writeExecTestFile(t, dir, "ralph.toml", testConfigWithRegent())
 	writeExecTestFile(t, dir, "PLAN.md", "# Plan\n")
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	// Regent gives up after 0 retries — must be an error.
 	if err == nil {
 		t.Fatal("expected error — Regent should give up after 0 retries")
@@ -509,7 +763,7 @@ func TestExecuteLoop_RegentEnabled_PromptExists_GitFails(t *testing.T) {
 func TestExecuteSmartRun_ConfigNotFound(t *testing.T) {
 	t.Chdir(t.TempDir())
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when ralph.toml not found")
 	}
@@ -526,7 +780,7 @@ func TestExecuteSmartRun_NeedsPlan_PromptMissing(t *testing.T) {
 	// No CHRONICLE.md → needsPlanPhase returns true.
 	// No PLAN.md → plan phase fails reading it.
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when plan prompt file missing")
 	}
@@ -544,7 +798,7 @@ func TestExecuteSmartRun_SkipPlan_BuildPromptMissing(t *testing.T) {
 	writeExecTestFile(t, dir, "CHRONICLE.md", "# Plan\n\nSome content.\n")
 	// BUILD.md absent → build loop fails reading it.
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error when build prompt file missing")
 	}
@@ -559,7 +813,7 @@ func TestExecuteSmartRun_ConfigInvalid(t *testing.T) {
 	// Empty plan.prompt_file triggers Validate() error.
 	writeExecTestFile(t, dir, "ralph.toml", "[plan]\nprompt_file = \"\"\n[build]\nprompt_file = \"b.md\"\n")
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected validation error")
 	}
@@ -577,7 +831,7 @@ func TestExecuteSmartRun_RegentEnabled_PromptMissing(t *testing.T) {
 	// No PLAN.md → plan phase fails reading it.
 	// Regent gives up after 0 retries and returns max-retries error.
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error — Regent should give up (max_retries=0)")
 	}
@@ -596,7 +850,7 @@ func TestExecuteLoop_StoreUnavailable(t *testing.T) {
 		t.Fatalf("WriteFile .ralph: %v", err)
 	}
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error from git operations")
 	}
@@ -614,7 +868,7 @@ func TestExecuteSmartRun_StoreUnavailable(t *testing.T) {
 		t.Fatalf("WriteFile .ralph: %v", err)
 	}
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error from git operations")
 	}
@@ -629,7 +883,7 @@ func TestExecuteLoop_NotificationsURLSet(t *testing.T) {
 	writeExecTestFile(t, dir, "ralph.toml", cfg)
 	writeExecTestFile(t, dir, "PLAN.md", "# Plan\n")
 
-	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false)
+	err := executeLoop(loop.ModePlan, 1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error from git operations")
 	}
@@ -648,7 +902,7 @@ func TestExecuteSmartRun_NotificationsURLSet(t *testing.T) {
 	writeExecTestFile(t, dir, "CHRONICLE.md", "# Done\n\nSome content.\n")
 	writeExecTestFile(t, dir, "BUILD.md", "# Build\n")
 
-	err := executeSmartRun(1, true, false, "", false, false)
+	err := executeSmartRun(1, true, false, "", false, false, "")
 	if err == nil {
 		t.Fatal("expected error from git operations")
 	}
@@ -849,7 +1103,7 @@ func TestExecuteLoop_Roam_StaysOnCurrentBranch(t *testing.T) {
 	branchBefore := strings.TrimSpace(string(outBefore))
 
 	// roam=true: should stay on the current branch (no sweep branch creation).
-	_ = executeLoop(loop.ModeBuild, 1, true, true, "", false, false)
+	_ = executeLoop(loop.ModeBuild, 1, true, true, "", false, false, "")
 
 	after := exec.Command("git", "branch", "--show-current")
 	after.Dir = dir

--- a/cmd/ralph/format.go
+++ b/cmd/ralph/format.go
@@ -25,8 +25,12 @@ func (f lineFormatter) format(entry loop.LogEntry) string {
 		return tui.RenderLogLine(entry, 200, tui.NewTheme(""))
 	}
 	ts := entry.Timestamp.Format("15:04:05")
-	if entry.Kind == loop.LogRegent {
-		return fmt.Sprintf("[%s]  🛡️  Regent: %s", ts, entry.Message)
+	agentPrefix := ""
+	if entry.Agent != "" {
+		agentPrefix = fmt.Sprintf("[%s] ", entry.Agent)
 	}
-	return fmt.Sprintf("[%s]  %s", ts, entry.Message)
+	if entry.Kind == loop.LogRegent {
+		return fmt.Sprintf("[%s]  🛡️  Regent: %s%s", ts, agentPrefix, entry.Message)
+	}
+	return fmt.Sprintf("[%s]  %s%s", ts, agentPrefix, entry.Message)
 }

--- a/cmd/ralph/format_test.go
+++ b/cmd/ralph/format_test.go
@@ -56,6 +56,26 @@ func TestLineFormatter_PlainMode(t *testing.T) {
 			want: "[14:23:01]  claude exited with error",
 		},
 		{
+			name: "agent entry — agent prefix included",
+			entry: loop.LogEntry{
+				Kind:      loop.LogInfo,
+				Timestamp: ts,
+				Agent:     "codex",
+				Message:   "starting iteration 3",
+			},
+			want: "[14:23:01]  [codex] starting iteration 3",
+		},
+		{
+			name: "regent entry — includes agent prefix when present",
+			entry: loop.LogEntry{
+				Kind:      loop.LogRegent,
+				Timestamp: ts,
+				Agent:     "codex",
+				Message:   "retrying",
+			},
+			want: "[14:23:01]  🛡️  Regent: [codex] retrying",
+		},
+		{
 			name: "git push entry — no special prefix",
 			entry: loop.LogEntry{
 				Kind:      loop.LogGitPush,

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -35,7 +35,7 @@ func rootCmd() *cobra.Command {
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if os.Getenv("ANTHROPIC_API_KEY") != "" {
 				noColor, _ := cmd.Root().PersistentFlags().GetBool("no-color")
-				msg := "WARNING: ANTHROPIC_API_KEY is set. Claude may use direct API billing\n" +
+				msg := "WARNING: ANTHROPIC_API_KEY is set. Claude-based runs may use direct API billing\n" +
 					"instead of your subscription. Unset it to avoid unexpected charges."
 				if noColor {
 					fmt.Fprintln(os.Stderr, msg)

--- a/cmd/ralph/process_unix.go
+++ b/cmd/ralph/process_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}

--- a/cmd/ralph/process_windows.go
+++ b/cmd/ralph/process_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+const processQueryLimitedInformation = 0x1000
+
+func processExists(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := syscall.OpenProcess(processQueryLimitedInformation, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	_ = syscall.CloseHandle(h)
+	return true
+}

--- a/cmd/ralph/speckit_cmds_test.go
+++ b/cmd/ralph/speckit_cmds_test.go
@@ -46,6 +46,7 @@ func TestSpecifyCmd_WithSpecFlag_CreatesDir(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	initGitRepoOnBranch(t, dir, "main")
+	t.Setenv("PATH", "")
 
 	cmd := specifyCmd()
 	if err := cmd.Flags().Set("spec", "004-my-feature"); err != nil {
@@ -298,6 +299,7 @@ func TestSpeckitPlanCmd_AllPrereqs_ReachesSpeckit(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	initGitRepoOnBranch(t, dir, "main")
+	t.Setenv("PATH", "")
 
 	specDir := filepath.Join(dir, "specs", "004-feature")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
@@ -325,6 +327,7 @@ func TestClarifyCmd_AllPrereqs_ReachesSpeckit(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	initGitRepoOnBranch(t, dir, "main")
+	t.Setenv("PATH", "")
 
 	specDir := filepath.Join(dir, "specs", "004-feature")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
@@ -351,6 +354,7 @@ func TestSpeckitTasksCmd_AllPrereqs_ReachesSpeckit(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	initGitRepoOnBranch(t, dir, "main")
+	t.Setenv("PATH", "")
 
 	specDir := filepath.Join(dir, "specs", "004-feature")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
@@ -377,6 +381,7 @@ func TestSpeckitRunCmd_AllPrereqs_ReachesSpeckit(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)
 	initGitRepoOnBranch(t, dir, "main")
+	t.Setenv("PATH", "")
 
 	specDir := filepath.Join(dir, "specs", "004-feature")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
@@ -436,6 +441,7 @@ func TestExecuteSpeckit_InteractiveVsNonInteractive(t *testing.T) {
 	}
 
 	t.Run("interactive omits -p flag", func(t *testing.T) {
+		t.Setenv("PATH", "")
 		err := executeSpeckit(context.Background(), "speckit.clarify", nil, true)
 		if !isNotFlagErr(err) {
 			t.Errorf("interactive executeSpeckit produced flag error: %v", err)
@@ -443,6 +449,7 @@ func TestExecuteSpeckit_InteractiveVsNonInteractive(t *testing.T) {
 	})
 
 	t.Run("non-interactive uses -p flag", func(t *testing.T) {
+		t.Setenv("PATH", "")
 		err := executeSpeckit(context.Background(), "speckit.plan", nil, false)
 		if !isNotFlagErr(err) {
 			t.Errorf("non-interactive executeSpeckit produced flag error: %v", err)

--- a/cmd/ralph/wiring.go
+++ b/cmd/ralph/wiring.go
@@ -152,7 +152,7 @@ func runWithStateTracking(ctx context.Context, lp *loop.Loop, dir string, gitRun
 	events := make(chan loop.LogEntry, 128)
 	lp.Events = events
 
-	st := newStateTracker(dir, mode, gitRunner)
+	st := newStateTracker(dir, mode, lp.AgentType, gitRunner)
 	st.save()
 
 	drainDone := make(chan struct{})
@@ -195,7 +195,7 @@ func runWithTUIAndState(ctx context.Context, lp *loop.Loop, dir string, gitRunne
 
 	lp.Events = loopEvents
 
-	st := newStateTracker(dir, mode, gitRunner)
+	st := newStateTracker(dir, mode, lp.AgentType, gitRunner)
 	st.save()
 
 	specFiles, _ := spec.List(dir)
@@ -251,13 +251,14 @@ type stateTracker struct {
 	dir   string
 }
 
-func newStateTracker(dir, mode string, gitRunner *git.Runner) *stateTracker {
+func newStateTracker(dir, mode, agent string, gitRunner *git.Runner) *stateTracker {
 	branch, _ := gitRunner.CurrentBranch()
 	now := time.Now()
 	return &stateTracker{
 		dir: dir,
 		state: regent.State{
 			RalphPID:     os.Getpid(),
+			Agent:        agent,
 			Branch:       branch,
 			Mode:         mode,
 			StartedAt:    now,
@@ -278,6 +279,10 @@ func (s *stateTracker) trackEntry(entry loop.LogEntry) {
 	}
 	if entry.Commit != "" {
 		s.state.LastCommit = entry.Commit
+		changed = true
+	}
+	if entry.Agent != "" {
+		s.state.Agent = entry.Agent
 		changed = true
 	}
 	if entry.Branch != "" {
@@ -316,7 +321,7 @@ type loopController struct {
 	mu        sync.Mutex
 	cancel    context.CancelFunc
 	done      chan struct{} // closed when the active runLoop goroutine exits; nil when idle
-	// agent overrides the default claude binary; nil → loop.NewClaudeAgent().
+	// agent overrides the resolved runtime agent when non-nil.
 	// Used in tests to inject a fast-failing fake.
 	agent claude.Agent
 }
@@ -375,14 +380,28 @@ func (lc *loopController) Shutdown() {
 func (lc *loopController) runLoop(ctx context.Context, mode string, done chan struct{}) {
 	defer close(done)
 	agent := lc.agent
+	agentType, err := resolveAgent(lc.cfg, "")
+	if err != nil {
+		lc.emitLoopError(err)
+		return
+	}
+	if err := validateAgentFlow(agentType, false, true); err != nil {
+		lc.emitLoopError(err)
+		return
+	}
 	if agent == nil {
-		agent = loop.NewClaudeAgent()
+		agent, err = buildAgent(agentType)
+		if err != nil {
+			lc.emitLoopError(err)
+			return
+		}
 	}
 	lp := &loop.Loop{
-		Agent:  agent,
-		Git:    lc.gitRunner,
-		Config: lc.cfg,
-		Dir:    lc.dir,
+		Agent:     agent,
+		AgentType: agentType,
+		Git:       lc.gitRunner,
+		Config:    lc.cfg,
+		Dir:       lc.dir,
 	}
 	loopEvents := make(chan loop.LogEntry, 128)
 	lp.Events = loopEvents
@@ -427,6 +446,17 @@ func (lc *loopController) runLoop(ctx context.Context, mode string, done chan st
 	lc.mu.Unlock()
 
 	_ = runErr
+}
+
+func (lc *loopController) emitLoopError(err error) {
+	select {
+	case lc.tuiSend <- loop.LogEntry{Kind: loop.LogError, Message: fmt.Sprintf("Error: %v", err)}:
+	default:
+	}
+	lc.mu.Lock()
+	lc.cancel = nil
+	lc.done = nil
+	lc.mu.Unlock()
 }
 
 // runDashboard launches the TUI in idle (dashboard) state with no loop running.

--- a/cmd/ralph/wiring_test.go
+++ b/cmd/ralph/wiring_test.go
@@ -36,13 +36,16 @@ func TestNewStateTracker(t *testing.T) {
 	initGitRepo(t, dir)
 
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "build", runner)
+	st := newStateTracker(dir, "build", "", runner)
 
 	if st.state.RalphPID == 0 {
 		t.Error("expected non-zero PID")
 	}
 	if st.state.Mode != "build" {
 		t.Errorf("Mode = %q, want %q", st.state.Mode, "build")
+	}
+	if st.state.Agent != "" {
+		t.Errorf("Agent = %q, want empty", st.state.Agent)
 	}
 	if st.state.Branch == "" {
 		t.Error("expected non-empty branch")
@@ -59,11 +62,12 @@ func TestStateTrackerTrackEntry(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "plan", runner)
+	st := newStateTracker(dir, "plan", "", runner)
 
 	st.trackEntry(loop.LogEntry{
 		Iteration: 3,
 		TotalCost: 1.50,
+		Agent:     "codex",
 		Commit:    "abc1234 feat: add stuff",
 		Branch:    "feat/test",
 		Mode:      "build",
@@ -74,6 +78,9 @@ func TestStateTrackerTrackEntry(t *testing.T) {
 	}
 	if st.state.TotalCostUSD != 1.50 {
 		t.Errorf("TotalCostUSD = %f, want 1.50", st.state.TotalCostUSD)
+	}
+	if st.state.Agent != "codex" {
+		t.Errorf("Agent = %q, want %q", st.state.Agent, "codex")
 	}
 	if st.state.LastCommit != "abc1234 feat: add stuff" {
 		t.Errorf("LastCommit = %q, want %q", st.state.LastCommit, "abc1234 feat: add stuff")
@@ -90,7 +97,7 @@ func TestStateTrackerZeroValuesPreserved(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "build", runner)
+	st := newStateTracker(dir, "build", "", runner)
 
 	st.trackEntry(loop.LogEntry{Iteration: 5, Branch: "main"})
 	st.trackEntry(loop.LogEntry{Message: "just info"})
@@ -107,7 +114,7 @@ func TestStateTrackerSave(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "build", runner)
+	st := newStateTracker(dir, "build", "", runner)
 
 	st.trackEntry(loop.LogEntry{Iteration: 2, TotalCost: 0.75})
 	st.save()
@@ -128,11 +135,11 @@ func TestStateTrackerLivePersistence(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "build", runner)
+	st := newStateTracker(dir, "build", "", runner)
 	st.save()
 
 	// trackEntry with meaningful fields auto-saves to disk
-	st.trackEntry(loop.LogEntry{Iteration: 3, TotalCost: 1.25, Branch: "feat/live"})
+	st.trackEntry(loop.LogEntry{Iteration: 3, TotalCost: 1.25, Agent: "codex", Branch: "feat/live"})
 
 	state, err := regent.LoadState(dir)
 	if err != nil {
@@ -146,6 +153,9 @@ func TestStateTrackerLivePersistence(t *testing.T) {
 	}
 	if state.Branch != "feat/live" {
 		t.Errorf("live Branch = %q, want %q", state.Branch, "feat/live")
+	}
+	if state.Agent != "codex" {
+		t.Errorf("live Agent = %q, want %q", state.Agent, "codex")
 	}
 
 	// trackEntry with no meaningful changes does not overwrite disk state
@@ -165,7 +175,7 @@ func TestStateTrackerFinish(t *testing.T) {
 		dir := t.TempDir()
 		initGitRepo(t, dir)
 		runner := git.NewRunner(dir)
-		st := newStateTracker(dir, "build", runner)
+		st := newStateTracker(dir, "build", "", runner)
 
 		st.finish(nil)
 
@@ -185,7 +195,7 @@ func TestStateTrackerFinish(t *testing.T) {
 		dir := t.TempDir()
 		initGitRepo(t, dir)
 		runner := git.NewRunner(dir)
-		st := newStateTracker(dir, "build", runner)
+		st := newStateTracker(dir, "build", "", runner)
 
 		st.finish(context.Canceled)
 
@@ -202,7 +212,7 @@ func TestStateTrackerFinish(t *testing.T) {
 		dir := t.TempDir()
 		initGitRepo(t, dir)
 		runner := git.NewRunner(dir)
-		st := newStateTracker(dir, "build", runner)
+		st := newStateTracker(dir, "build", "", runner)
 
 		st.finish(errors.New("something broke"))
 
@@ -220,7 +230,7 @@ func TestStateTrackerLastOutputAt(t *testing.T) {
 	dir := t.TempDir()
 	initGitRepo(t, dir)
 	runner := git.NewRunner(dir)
-	st := newStateTracker(dir, "build", runner)
+	st := newStateTracker(dir, "build", "", runner)
 
 	before := time.Now()
 	time.Sleep(10 * time.Millisecond)
@@ -686,6 +696,34 @@ func TestLoopController_StartLoop_ForwardGoroutine(t *testing.T) {
 
 	ctrl.StartLoop("plan")
 	waitForIdle(t, ctrl)
+}
+
+func TestLoopController_StartLoop_CodexDashboardUnsupported(t *testing.T) {
+	tuiSend := make(chan loop.LogEntry, 8)
+	cfg := config.Defaults()
+	cfg.Agent.Type = config.AgentCodex
+
+	ctrl := &loopController{
+		cfg:      &cfg,
+		dir:      t.TempDir(),
+		tuiSend:  tuiSend,
+		outerCtx: context.Background(),
+	}
+
+	ctrl.StartLoop("plan")
+	waitForIdle(t, ctrl)
+
+	close(tuiSend)
+	var found bool
+	for entry := range tuiSend {
+		if entry.Kind == loop.LogError && strings.Contains(entry.Message, "codex agent unsupported for dashboard mode") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected dashboard-mode codex error event")
+	}
 }
 
 // --- Tests for finishTUI ---

--- a/internal/codex/agent.go
+++ b/internal/codex/agent.go
@@ -1,0 +1,75 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/LISSConsulting/RalphSpec/internal/claude"
+)
+
+type Agent struct {
+	Executable string
+}
+
+func NewAgent() *Agent {
+	return &Agent{Executable: "codex"}
+}
+
+func (a *Agent) Run(ctx context.Context, prompt string, opts claude.RunOptions) (<-chan claude.Event, error) {
+	args := a.buildArgs(prompt, opts)
+	exe := a.Executable
+	if exe == "" {
+		exe = "codex"
+	}
+	cmd := exec.CommandContext(ctx, exe, args...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("codex agent: stdout pipe: %w", err)
+	}
+	var stderrBuf bytes.Buffer
+	cmd.Stderr = &stderrBuf
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("codex agent: start: %w", err)
+	}
+	parsed := ParseStream(stdout)
+	ch := make(chan claude.Event, 64)
+	go func() {
+		defer close(ch)
+		for ev := range parsed {
+			ch <- ev
+		}
+		if err := cmd.Wait(); err != nil && ctx.Err() == nil {
+			msg := fmt.Sprintf("codex exited: %v", err)
+			if detail := strings.TrimSpace(stderrBuf.String()); detail != "" {
+				msg = fmt.Sprintf("codex exited: %v: %s", err, detail)
+			}
+			ch <- claude.ErrorEvent(msg)
+		}
+	}()
+	return ch, nil
+}
+
+func (a *Agent) buildArgs(prompt string, opts claude.RunOptions) []string {
+	args := []string{"exec", "--json", "--full-auto"}
+	if opts.Dir != "" {
+		args = append(args, "--cd", opts.Dir)
+	}
+	if opts.Model != "" {
+		args = append(args, "--model", opts.Model)
+	}
+	args = append(args, prompt)
+	return args
+}
+
+func CheckAvailable(executable string) error {
+	if executable == "" {
+		executable = "codex"
+	}
+	if _, err := exec.LookPath(executable); err != nil {
+		return fmt.Errorf("codex executable not found on PATH")
+	}
+	return nil
+}

--- a/internal/codex/agent_test.go
+++ b/internal/codex/agent_test.go
@@ -1,0 +1,204 @@
+package codex
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/LISSConsulting/RalphSpec/internal/claude"
+)
+
+func init() {
+	if os.Getenv("_FAKE_CODEX") != "1" {
+		return
+	}
+	if f := os.Getenv("_FAKE_CODEX_STDOUT_FILE"); f != "" {
+		if data, err := os.ReadFile(f); err == nil {
+			_, _ = os.Stdout.Write(data)
+		}
+	}
+	if s := os.Getenv("_FAKE_CODEX_STDERR"); s != "" {
+		_, _ = fmt.Fprint(os.Stderr, s)
+	}
+	if os.Getenv("_FAKE_CODEX_SLEEP") == "1" {
+		time.Sleep(time.Minute)
+	}
+	code := 0
+	if s := os.Getenv("_FAKE_CODEX_EXIT"); s != "" {
+		_, _ = fmt.Sscan(s, &code)
+	}
+	os.Exit(code)
+}
+
+func TestNewAgent(t *testing.T) {
+	agent := NewAgent()
+	if agent.Executable != "codex" {
+		t.Errorf("expected executable %q, got %q", "codex", agent.Executable)
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	agent := &Agent{}
+	args := agent.buildArgs("test prompt", claude.RunOptions{Dir: "/tmp/project", Model: "gpt-5"})
+
+	for _, want := range []string{"exec", "--json", "--full-auto", "--cd", "/tmp/project", "--model", "gpt-5", "test prompt"} {
+		if !containsArg(args, want) {
+			t.Fatalf("args %v missing %q", args, want)
+		}
+	}
+}
+
+func TestAgentRun(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	t.Run("streams events from subprocess", func(t *testing.T) {
+		output := strings.Join([]string{
+			`{"type":"message","text":"thinking"}`,
+			`{"type":"tool_call","tool_name":"read_file","tool_input":{"path":"main.go"}}`,
+			`{"type":"result","cost_usd":0.10,"duration_ms":2500,"subtype":"success"}`,
+		}, "\n")
+		agent := setUpFakeCodex(t, exe, 0, output, "")
+
+		ch, err := agent.Run(context.Background(), "test prompt", claude.RunOptions{Dir: t.TempDir()})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var events []claude.Event
+		for ev := range ch {
+			events = append(events, ev)
+		}
+
+		if len(events) != 3 {
+			t.Fatalf("expected 3 events, got %d", len(events))
+		}
+		if events[0].Type != claude.EventText {
+			t.Fatalf("expected text event, got %#v", events[0])
+		}
+		if events[1].Type != claude.EventToolUse || events[1].ToolName != "read_file" {
+			t.Fatalf("unexpected tool event: %#v", events[1])
+		}
+		if events[2].Type != claude.EventResult || events[2].Subtype != "success" {
+			t.Fatalf("unexpected result event: %#v", events[2])
+		}
+	})
+
+	t.Run("non-zero exit includes stderr in error", func(t *testing.T) {
+		agent := setUpFakeCodex(t, exe, 1, "", "login required")
+
+		ch, err := agent.Run(context.Background(), "test", claude.RunOptions{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		var last claude.Event
+		for ev := range ch {
+			last = ev
+		}
+		if last.Type != claude.EventError {
+			t.Fatalf("expected final error event, got %#v", last)
+		}
+		if !strings.Contains(last.Error, "login required") {
+			t.Fatalf("expected stderr in error, got %q", last.Error)
+		}
+	})
+
+	t.Run("invalid executable returns start error", func(t *testing.T) {
+		agent := &Agent{Executable: filepath.Join(t.TempDir(), "missing-codex")}
+		_, err := agent.Run(context.Background(), "test", claude.RunOptions{})
+		if err == nil {
+			t.Fatal("expected error for invalid executable")
+		}
+		if !strings.Contains(err.Error(), "codex agent: start:") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestCheckAvailable(t *testing.T) {
+	t.Run("missing binary returns actionable error", func(t *testing.T) {
+		t.Setenv("PATH", "")
+		err := CheckAvailable("")
+		if err == nil {
+			t.Fatal("expected missing-binary error")
+		}
+		if !strings.Contains(err.Error(), "codex executable not found on PATH") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("present binary succeeds", func(t *testing.T) {
+		dir := t.TempDir()
+		name := writeFakeExecutable(t, dir, "codex")
+		prependPath(t, dir)
+		if err := CheckAvailable(name); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func setUpFakeCodex(t *testing.T, exe string, exitCode int, stdout, stderr string) *Agent {
+	t.Helper()
+	dir := t.TempDir()
+	stdoutFile := filepath.Join(dir, "stdout.txt")
+	if err := os.WriteFile(stdoutFile, []byte(stdout), 0644); err != nil {
+		t.Fatalf("write stdout file: %v", err)
+	}
+	t.Setenv("_FAKE_CODEX", "1")
+	t.Setenv("_FAKE_CODEX_STDOUT_FILE", stdoutFile)
+	if exitCode != 0 {
+		t.Setenv("_FAKE_CODEX_EXIT", fmt.Sprintf("%d", exitCode))
+	}
+	if stderr != "" {
+		t.Setenv("_FAKE_CODEX_STDERR", stderr)
+	}
+	return &Agent{Executable: exe}
+}
+
+func writeFakeExecutable(t *testing.T, dir, base string) string {
+	t.Helper()
+	name := base
+	content := "#!/bin/sh\nexit 0\n"
+	if runtime.GOOS == "windows" {
+		name += ".cmd"
+		content = "@echo off\r\nexit /b 0\r\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0755); err != nil {
+		t.Fatalf("write fake executable: %v", err)
+	}
+	return name
+}
+
+func prependPath(t *testing.T, dir string) {
+	t.Helper()
+	oldPath := os.Getenv("PATH")
+	sep := ":"
+	if runtime.GOOS == "windows" {
+		sep = ";"
+	}
+	if oldPath == "" {
+		t.Setenv("PATH", dir)
+		return
+	}
+	t.Setenv("PATH", dir+sep+oldPath)
+}
+
+func containsArg(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
+var _ claude.Agent = (*Agent)(nil)

--- a/internal/codex/parser.go
+++ b/internal/codex/parser.go
@@ -1,0 +1,149 @@
+package codex
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/LISSConsulting/RalphSpec/internal/claude"
+)
+
+// ParseStream reads Codex JSONL output and emits shared agent events.
+func ParseStream(r io.Reader) <-chan claude.Event {
+	ch := make(chan claude.Event, 64)
+	go func() {
+		defer close(ch)
+		br := bufio.NewReaderSize(r, 64*1024)
+		for {
+			line, err := br.ReadBytes('\n')
+			line = bytes.TrimRight(line, "\r\n")
+			if len(line) > 0 {
+				for _, ev := range parseLine(line) {
+					ch <- ev
+				}
+			}
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					ch <- claude.ErrorEvent(fmt.Sprintf("stream read error: %v", err))
+				}
+				return
+			}
+		}
+	}()
+	return ch
+}
+
+type streamMessage struct {
+	Type       string         `json:"type"`
+	Role       string         `json:"role"`
+	Name       string         `json:"name"`
+	Content    any            `json:"content"`
+	Text       string         `json:"text"`
+	Delta      string         `json:"delta"`
+	ToolName   string         `json:"tool_name"`
+	ToolInput  map[string]any `json:"tool_input"`
+	Input      map[string]any `json:"input"`
+	Result     string         `json:"result"`
+	Error      string         `json:"error"`
+	IsError    bool           `json:"is_error"`
+	CostUSD    float64        `json:"cost_usd"`
+	DurationMS float64        `json:"duration_ms"`
+	DurationS  float64        `json:"duration_seconds"`
+	Subtype    string         `json:"subtype"`
+	Status     string         `json:"status"`
+}
+
+func parseLine(line []byte) []claude.Event {
+	var msg streamMessage
+	if err := json.Unmarshal(line, &msg); err != nil {
+		return nil
+	}
+
+	if text := messageText(msg); text != "" {
+		return []claude.Event{claude.TextEvent(text)}
+	}
+
+	toolName, toolInput := messageTool(msg)
+	if toolName != "" {
+		return []claude.Event{claude.ToolUseEvent(toolName, toolInput)}
+	}
+
+	if msg.IsError || msg.Error != "" || msg.Type == "error" {
+		errText := msg.Error
+		if errText == "" {
+			errText = msg.Result
+		}
+		if errText == "" {
+			errText = "codex run failed"
+		}
+		return []claude.Event{claude.ErrorEvent(errText)}
+	}
+
+	if isResultMessage(msg) {
+		duration := msg.DurationS
+		if duration == 0 && msg.DurationMS > 0 {
+			duration = msg.DurationMS / 1000
+		}
+		subtype := msg.Subtype
+		if subtype == "" {
+			subtype = msg.Status
+		}
+		if subtype == "" {
+			subtype = "success"
+		}
+		return []claude.Event{claude.ResultEvent(msg.CostUSD, duration, subtype)}
+	}
+
+	return nil
+}
+
+func messageText(msg streamMessage) string {
+	for _, s := range []string{msg.Text, msg.Delta, textFromContent(msg.Content)} {
+		if strings.TrimSpace(s) != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func messageTool(msg streamMessage) (string, map[string]any) {
+	name := msg.ToolName
+	if name == "" {
+		name = msg.Name
+	}
+	if name == "" {
+		return "", nil
+	}
+	input := msg.ToolInput
+	if len(input) == 0 {
+		input = msg.Input
+	}
+	return name, input
+}
+
+func isResultMessage(msg streamMessage) bool {
+	return msg.Type == "result" || msg.Type == "response.completed" || msg.Status == "completed" || msg.Subtype == "success"
+}
+
+func textFromContent(content any) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []any:
+		var parts []string
+		for _, item := range v {
+			if m, ok := item.(map[string]any); ok {
+				if text, _ := m["text"].(string); strings.TrimSpace(text) != "" {
+					parts = append(parts, text)
+				}
+			}
+		}
+		return strings.Join(parts, "\n")
+	default:
+		return ""
+	}
+}

--- a/internal/codex/parser_test.go
+++ b/internal/codex/parser_test.go
@@ -1,0 +1,34 @@
+package codex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/LISSConsulting/RalphSpec/internal/claude"
+)
+
+func TestParseStream(t *testing.T) {
+	input := strings.Join([]string{
+		`{"type":"message","text":"thinking"}`,
+		`{"type":"tool_call","tool_name":"read_file","tool_input":{"path":"main.go"}}`,
+		`{"type":"result","cost_usd":0.12,"duration_ms":1500,"subtype":"success"}`,
+	}, "\n")
+
+	var events []claude.Event
+	for ev := range ParseStream(strings.NewReader(input)) {
+		events = append(events, ev)
+	}
+
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+	if events[0].Type != claude.EventText || events[0].Text != "thinking" {
+		t.Fatalf("unexpected first event: %#v", events[0])
+	}
+	if events[1].Type != claude.EventToolUse || events[1].ToolName != "read_file" {
+		t.Fatalf("unexpected tool event: %#v", events[1])
+	}
+	if events[2].Type != claude.EventResult || events[2].Subtype != "success" {
+		t.Fatalf("unexpected result event: %#v", events[2])
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,7 +22,9 @@ var hexColorRe = regexp.MustCompile(`^#[0-9A-Fa-f]{6}$`)
 // Config is the top-level ralph.toml configuration.
 type Config struct {
 	Project       ProjectConfig       `toml:"project"`
+	Agent         AgentConfig         `toml:"agent"`
 	Claude        ClaudeConfig        `toml:"claude"`
+	Codex         CodexConfig         `toml:"codex"`
 	Plan          PlanConfig          `toml:"plan"`
 	Build         BuildConfig         `toml:"build"`
 	Git           GitConfig           `toml:"git"`
@@ -30,6 +32,16 @@ type Config struct {
 	TUI           TUIConfig           `toml:"tui"`
 	Notifications NotificationsConfig `toml:"notifications"`
 	Worktree      WorktreeConfig      `toml:"worktree"`
+}
+
+const (
+	AgentClaude = "claude"
+	AgentCodex  = "codex"
+)
+
+// AgentConfig controls which agent Ralph should use by default.
+type AgentConfig struct {
+	Type string `toml:"type"`
 }
 
 // WorktreeConfig controls git worktree support via worktrunk.
@@ -81,6 +93,11 @@ type ClaudeConfig struct {
 	DangerSkipPermissions bool   `toml:"danger_skip_permissions"`
 }
 
+// CodexConfig controls the Codex CLI invocation.
+type CodexConfig struct {
+	Model string `toml:"model"`
+}
+
 // PlanConfig controls the plan loop.
 type PlanConfig struct {
 	PromptFile    string `toml:"prompt_file"`
@@ -118,6 +135,9 @@ func (c *Config) Validate() error {
 
 	if c.Plan.PromptFile == "" {
 		errs = append(errs, fmt.Errorf("plan.prompt_file must not be empty"))
+	}
+	if c.Agent.Type != "" && c.Agent.Type != AgentClaude && c.Agent.Type != AgentCodex {
+		errs = append(errs, fmt.Errorf("agent.type must be one of %s,%s", AgentClaude, AgentCodex))
 	}
 	if c.Build.PromptFile == "" {
 		errs = append(errs, fmt.Errorf("build.prompt_file must not be empty"))
@@ -174,10 +194,12 @@ func (c *Config) Validate() error {
 func Defaults() Config {
 	return Config{
 		Project: ProjectConfig{Name: ""},
+		Agent:   AgentConfig{Type: AgentClaude},
 		Claude: ClaudeConfig{
 			Model:                 "sonnet",
 			DangerSkipPermissions: true,
 		},
+		Codex: CodexConfig{},
 		Plan: PlanConfig{
 			PromptFile:    "PLAN.md",
 			MaxIterations: 3,
@@ -290,10 +312,16 @@ func InitFile(dir string) (string, error) {
 [project]
 name = ""
 
+[agent]
+type = "claude"
+
 [claude]
 model = "sonnet"
 max_turns = 0  # 0 = unlimited agentic turns per iteration
 danger_skip_permissions = true
+
+[codex]
+model = ""
 
 [plan]
 prompt_file = "PLAN.md"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,7 +15,9 @@ func TestDefaults(t *testing.T) {
 		got  any
 		want any
 	}{
+		{"agent.type", cfg.Agent.Type, AgentClaude},
 		{"claude.model", cfg.Claude.Model, "sonnet"},
+		{"codex.model", cfg.Codex.Model, ""},
 		{"claude.max_turns", cfg.Claude.MaxTurns, 0},
 		{"claude.danger_skip_permissions", cfg.Claude.DangerSkipPermissions, true},
 		{"plan.prompt_file", cfg.Plan.PromptFile, "PLAN.md"},
@@ -59,6 +61,9 @@ func TestLoad(t *testing.T) {
 [project]
 name = "TestProject"
 
+[agent]
+type = "codex"
+
 [claude]
 model = "opus"
 max_turns = 25
@@ -87,6 +92,9 @@ hang_timeout_seconds = 600
 [tui]
 accent_color = "#FF0000"
 log_retention = 10
+
+[codex]
+model = "gpt-5-codex"
 `
 		path := filepath.Join(dir, "ralph.toml")
 		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
@@ -104,7 +112,9 @@ log_retention = 10
 			want any
 		}{
 			{"project.name", cfg.Project.Name, "TestProject"},
+			{"agent.type", cfg.Agent.Type, AgentCodex},
 			{"claude.model", cfg.Claude.Model, "opus"},
+			{"codex.model", cfg.Codex.Model, "gpt-5-codex"},
 			{"claude.max_turns", cfg.Claude.MaxTurns, 25},
 			{"claude.danger_skip_permissions", cfg.Claude.DangerSkipPermissions, false},
 			{"plan.prompt_file", cfg.Plan.PromptFile, "MY_PLAN.md"},

--- a/internal/config/scaffold_test.go
+++ b/internal/config/scaffold_test.go
@@ -367,5 +367,11 @@ func TestScaffoldProject(t *testing.T) {
 		if cfg.Claude.Model != "sonnet" {
 			t.Errorf("default model: got %q, want %q", cfg.Claude.Model, "sonnet")
 		}
+		if cfg.Agent.Type != AgentClaude {
+			t.Errorf("default agent.type: got %q, want %q", cfg.Agent.Type, AgentClaude)
+		}
+		if cfg.Codex.Model != "" {
+			t.Errorf("default codex.model: got %q, want empty", cfg.Codex.Model)
+		}
 	})
 }

--- a/internal/loop/event.go
+++ b/internal/loop/event.go
@@ -44,6 +44,7 @@ type LogEntry struct {
 	MaxIter   int
 
 	// Git state
+	Agent  string
 	Branch string
 	Commit string
 

--- a/internal/loop/event_test.go
+++ b/internal/loop/event_test.go
@@ -38,6 +38,9 @@ func TestEmitToChannel(t *testing.T) {
 	if len(entries) == 0 {
 		t.Fatal("expected events to be sent to channel")
 	}
+	if entries[0].Agent != config.AgentClaude {
+		t.Errorf("expected first event agent %q, got %q", config.AgentClaude, entries[0].Agent)
+	}
 
 	// Verify we got a mix of event types
 	kinds := map[LogKind]bool{}
@@ -263,5 +266,8 @@ func TestEmitBranchAndIterationInEvents(t *testing.T) {
 	}
 	if iterStart.Iteration != 1 {
 		t.Errorf("expected iteration 1, got %d", iterStart.Iteration)
+	}
+	if iterStart.Agent != config.AgentClaude {
+		t.Errorf("expected agent %q, got %q", config.AgentClaude, iterStart.Agent)
 	}
 }

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -37,6 +37,7 @@ type GitOps interface {
 // Loop orchestrates the prompt -> claude -> parse -> git iteration cycle.
 type Loop struct {
 	Agent            claude.Agent
+	AgentType        string
 	Git              GitOps
 	Config           *config.Config
 	Log              io.Writer       // output destination; defaults to os.Stdout
@@ -90,7 +91,8 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 
 	l.emit(LogEntry{
 		Kind:    LogInfo,
-		Message: fmt.Sprintf("Starting %s loop on branch %s (max: %s)", mode, branch, iterLabel(maxIter)),
+		Message: fmt.Sprintf("Starting %s loop with %s on branch %s (max: %s)", mode, l.agentName(), branch, iterLabel(maxIter)),
+		Agent:   l.agentName(),
 		Branch:  branch,
 		Commit:  commit,
 		MaxIter: maxIter,
@@ -105,6 +107,7 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 			l.emit(LogEntry{
 				Kind:    LogStopped,
 				Message: fmt.Sprintf("Loop stopped: %v", ctx.Err()),
+				Agent:   l.agentName(),
 			})
 			return ctx.Err()
 		default:
@@ -123,12 +126,14 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 				l.emit(LogEntry{
 					Kind:      LogSweepComplete,
 					Message:   fmt.Sprintf("Roam complete (%d iterations, $%.2f)", i, totalCost),
+					Agent:     l.agentName(),
 					TotalCost: totalCost,
 				})
 			} else {
 				l.emit(LogEntry{
 					Kind:      LogSpecComplete,
 					Message:   fmt.Sprintf("Spec complete (%d iterations, $%.2f)", i, totalCost),
+					Agent:     l.agentName(),
 					TotalCost: totalCost,
 				})
 			}
@@ -144,6 +149,7 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 		l.emit(LogEntry{
 			Kind:      LogInfo,
 			Message:   fmt.Sprintf("Running total: $%.2f", totalCost),
+			Agent:     l.agentName(),
 			TotalCost: totalCost,
 		})
 
@@ -154,6 +160,7 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 				l.emit(LogEntry{
 					Kind:    LogStopped,
 					Message: "Stop requested — exiting after this iteration",
+					Agent:   l.agentName(),
 				})
 				return nil
 			default:
@@ -164,6 +171,7 @@ func (l *Loop) Run(ctx context.Context, mode Mode, maxOverride int) error {
 	l.emit(LogEntry{
 		Kind:      LogDone,
 		Message:   fmt.Sprintf("Loop complete — %s iterations done, total cost: $%.2f", iterLabel(maxIter), totalCost),
+		Agent:     l.agentName(),
 		TotalCost: totalCost,
 		MaxIter:   maxIter,
 	})
@@ -174,6 +182,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 	l.emit(LogEntry{
 		Kind:      LogIterStart,
 		Message:   fmt.Sprintf("── iteration %d ──", n),
+		Agent:     l.agentName(),
 		Iteration: n,
 		MaxIter:   maxIter,
 		Branch:    branch,
@@ -190,12 +199,14 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 		l.emit(LogEntry{
 			Kind:    LogGitPull,
 			Message: fmt.Sprintf("Pulling %s", branch),
+			Agent:   l.agentName(),
 			Branch:  branch,
 		})
 		if pullErr := l.Git.Pull(branch); pullErr != nil {
 			l.emit(LogEntry{
 				Kind:    LogInfo,
 				Message: fmt.Sprintf("Pull failed: %v (continuing)", pullErr),
+				Agent:   l.agentName(),
 			})
 		}
 	}
@@ -206,6 +217,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 			l.emit(LogEntry{
 				Kind:    LogInfo,
 				Message: fmt.Sprintf("Stash pop failed: %v", popErr),
+				Agent:   l.agentName(),
 			})
 		}
 	}
@@ -213,19 +225,20 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 	// Capture HEAD before Claude runs to detect new commits afterward.
 	headBefore, _ := l.Git.LastCommit()
 
-	// Run Claude
+	// Run the selected agent.
 	l.emit(LogEntry{
 		Kind:    LogInfo,
-		Message: "Running Claude...",
+		Agent:   l.agentName(),
+		Message: fmt.Sprintf("Running %s...", l.agentName()),
 	})
 	events, agentErr := l.Agent.Run(ctx, prompt, claude.RunOptions{
-		Model:                 l.Config.Claude.Model,
-		MaxTurns:              l.Config.Claude.MaxTurns,
-		DangerSkipPermissions: l.Config.Claude.DangerSkipPermissions,
+		Model:                 l.agentModel(),
+		MaxTurns:              l.agentMaxTurns(),
+		DangerSkipPermissions: l.agentDangerSkipPermissions(),
 		Dir:                   l.Dir,
 	})
 	if agentErr != nil {
-		return 0, "", false, fmt.Errorf("start claude: %w", agentErr)
+		return 0, "", false, fmt.Errorf("start %s: %w", l.agentName(), agentErr)
 	}
 
 	// Drain events
@@ -235,6 +248,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 			l.emit(LogEntry{
 				Kind:      LogToolUse,
 				Message:   fmt.Sprintf("tool: %s  %s", ev.ToolName, summarizeInput(ev.ToolInput)),
+				Agent:     l.agentName(),
 				ToolName:  ev.ToolName,
 				ToolInput: summarizeInput(ev.ToolInput),
 			})
@@ -242,6 +256,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 			if ev.Text != "" {
 				l.emit(LogEntry{
 					Kind:    LogText,
+					Agent:   l.agentName(),
 					Message: ev.Text,
 				})
 			}
@@ -255,6 +270,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 			l.emit(LogEntry{
 				Kind:      LogIterComplete,
 				Message:   msg,
+				Agent:     l.agentName(),
 				Iteration: n,
 				CostUSD:   ev.CostUSD,
 				Duration:  ev.Duration,
@@ -263,6 +279,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 		case claude.EventError:
 			l.emit(LogEntry{
 				Kind:    LogError,
+				Agent:   l.agentName(),
 				Message: fmt.Sprintf("Error: %s", ev.Error),
 			})
 		}
@@ -273,6 +290,7 @@ func (l *Loop) iteration(ctx context.Context, n, maxIter int, prompt, branch str
 		if pushErr := l.pushIfNeeded(branch); pushErr != nil {
 			l.emit(LogEntry{
 				Kind:    LogError,
+				Agent:   l.agentName(),
 				Message: fmt.Sprintf("Push error: %v", pushErr),
 			})
 		}
@@ -294,6 +312,7 @@ func (l *Loop) stashIfDirty() (bool, error) {
 		l.emit(LogEntry{
 			Kind:    LogInfo,
 			Message: "Stashing uncommitted changes",
+			Agent:   l.agentName(),
 		})
 		if stashErr := l.Git.Stash(); stashErr != nil {
 			return false, fmt.Errorf("stash: %w", stashErr)
@@ -311,6 +330,7 @@ func (l *Loop) pushIfNeeded(branch string) error {
 		l.emit(LogEntry{
 			Kind:    LogInfo,
 			Message: fmt.Sprintf("Diff check failed: %v (pushing anyway)", err),
+			Agent:   l.agentName(),
 		})
 	}
 	if err == nil && !hasChanges {
@@ -319,6 +339,7 @@ func (l *Loop) pushIfNeeded(branch string) error {
 	l.emit(LogEntry{
 		Kind:    LogGitPush,
 		Message: fmt.Sprintf("Pushing %s", branch),
+		Agent:   l.agentName(),
 		Branch:  branch,
 	})
 	if pushErr := l.Git.Push(branch); pushErr != nil {
@@ -331,6 +352,7 @@ func (l *Loop) pushIfNeeded(branch string) error {
 	l.emit(LogEntry{
 		Kind:    LogGitPush,
 		Message: fmt.Sprintf("Pushed — last commit: %s", commit),
+		Agent:   l.agentName(),
 		Commit:  commit,
 		Branch:  branch,
 	})
@@ -378,6 +400,34 @@ func iterLabel(max int) string {
 		return "unlimited"
 	}
 	return fmt.Sprintf("%d", max)
+}
+
+func (l *Loop) agentName() string {
+	if l.AgentType != "" {
+		return l.AgentType
+	}
+	return config.AgentClaude
+}
+
+func (l *Loop) agentModel() string {
+	if l.agentName() == config.AgentCodex {
+		return l.Config.Codex.Model
+	}
+	return l.Config.Claude.Model
+}
+
+func (l *Loop) agentMaxTurns() int {
+	if l.agentName() == config.AgentCodex {
+		return 0
+	}
+	return l.Config.Claude.MaxTurns
+}
+
+func (l *Loop) agentDangerSkipPermissions() bool {
+	if l.agentName() == config.AgentCodex {
+		return false
+	}
+	return l.Config.Claude.DangerSkipPermissions
 }
 
 // augmentPrompt appends a ## Spec Context section to the prompt when applicable.

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -20,11 +20,13 @@ type mockAgent struct {
 	err        error
 	calls      int
 	lastPrompt string // captures the prompt passed to the most recent Run() call
+	lastOpts   claude.RunOptions
 }
 
-func (m *mockAgent) Run(_ context.Context, prompt string, _ claude.RunOptions) (<-chan claude.Event, error) {
+func (m *mockAgent) Run(_ context.Context, prompt string, opts claude.RunOptions) (<-chan claude.Event, error) {
 	m.calls++
 	m.lastPrompt = prompt
+	m.lastOpts = opts
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -213,6 +215,46 @@ func TestRun(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "agent failed") {
 			t.Errorf("error should contain agent message, got: %v", err)
+		}
+	})
+
+	t.Run("default claude config is preserved", func(t *testing.T) {
+		agent := &mockAgent{events: []claude.Event{claude.ResultEvent(0.05, 1.0, "success")}}
+		git := &mockGit{branch: "main", lastCommit: "abc123 initial"}
+		cfg := defaultTestConfig()
+		cfg.Plan.MaxIterations = 1
+		cfg.Claude.Model = "opus"
+		cfg.Claude.MaxTurns = 7
+		cfg.Claude.DangerSkipPermissions = true
+
+		lp, buf := setupTestLoop(t, agent, git, cfg)
+		err := lp.Run(context.Background(), ModePlan, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if agent.lastOpts.Model != "opus" || agent.lastOpts.MaxTurns != 7 || !agent.lastOpts.DangerSkipPermissions {
+			t.Fatalf("unexpected claude opts: %+v", agent.lastOpts)
+		}
+		if !strings.Contains(buf.String(), "with claude") {
+			t.Fatalf("expected log output to mention claude, got %q", buf.String())
+		}
+	})
+
+	t.Run("codex config uses codex model and skips claude-only options", func(t *testing.T) {
+		agent := &mockAgent{events: []claude.Event{claude.ResultEvent(0.05, 1.0, "success")}}
+		git := &mockGit{branch: "main", lastCommit: "abc123 initial"}
+		cfg := defaultTestConfig()
+		cfg.Plan.MaxIterations = 1
+		cfg.Codex.Model = "gpt-5-codex"
+
+		lp, _ := setupTestLoop(t, agent, git, cfg)
+		lp.AgentType = config.AgentCodex
+		err := lp.Run(context.Background(), ModePlan, 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if agent.lastOpts.Model != "gpt-5-codex" || agent.lastOpts.MaxTurns != 0 || agent.lastOpts.DangerSkipPermissions {
+			t.Fatalf("unexpected codex opts: %+v", agent.lastOpts)
 		}
 	})
 }

--- a/internal/regent/regent.go
+++ b/internal/regent/regent.go
@@ -183,6 +183,10 @@ func (r *Regent) UpdateState(entry loop.LogEntry) {
 		r.state.LastCommit = entry.Commit
 		changed = true
 	}
+	if entry.Agent != "" {
+		r.state.Agent = entry.Agent
+		changed = true
+	}
 	if entry.Branch != "" {
 		r.state.Branch = entry.Branch
 		changed = true
@@ -255,6 +259,7 @@ func (r *Regent) emit(msg string) {
 		Kind:      loop.LogRegent,
 		Timestamp: time.Now(),
 		Message:   msg,
+		Agent:     r.state.Agent,
 	}
 	// Sending to a closed channel panics in Go even in a non-blocking select.
 	// This can happen when saveState is called from the runWithRegent drain goroutine

--- a/internal/regent/regent_test.go
+++ b/internal/regent/regent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +23,20 @@ func defaultTestRegentConfig() config.RegentConfig {
 		RetryBackoffSeconds:   0, // no delay in tests
 		HangTimeoutSeconds:    0, // disabled in most tests
 	}
+}
+
+func passingCommand() string {
+	if runtime.GOOS == "windows" {
+		return "cmd /c exit 0"
+	}
+	return "true"
+}
+
+func failingCommand() string {
+	if runtime.GOOS == "windows" {
+		return "cmd /c exit 1"
+	}
+	return "false"
 }
 
 func TestSupervise(t *testing.T) {
@@ -569,7 +584,7 @@ func TestRunPostIterationTests(t *testing.T) {
 		dir := t.TempDir()
 		cfg := defaultTestRegentConfig()
 		cfg.RollbackOnTestFailure = true
-		cfg.TestCommand = "true"
+		cfg.TestCommand = passingCommand()
 		events := make(chan loop.LogEntry, 128)
 		g := &mockGit{branch: "main", lastCommit: "abc good commit"}
 		rgt := New(cfg, dir, g, events)
@@ -589,7 +604,7 @@ func TestRunPostIterationTests(t *testing.T) {
 		dir := t.TempDir()
 		cfg := defaultTestRegentConfig()
 		cfg.RollbackOnTestFailure = true
-		cfg.TestCommand = "false"
+		cfg.TestCommand = failingCommand()
 		events := make(chan loop.LogEntry, 128)
 		g := &mockGit{branch: "main", lastCommit: "abc1234 bad commit"}
 		rgt := New(cfg, dir, g, events)
@@ -615,7 +630,7 @@ func TestRunPostIterationTests(t *testing.T) {
 		dir := t.TempDir()
 		cfg := defaultTestRegentConfig()
 		cfg.RollbackOnTestFailure = true
-		cfg.TestCommand = "true"
+		cfg.TestCommand = passingCommand()
 		events := make(chan loop.LogEntry, 128)
 		g := &mockGit{branch: "main", lastCommit: "abc commit"}
 		rgt := New(cfg, dir, g, events)
@@ -649,7 +664,7 @@ func TestRunPostIterationTests(t *testing.T) {
 		dir := t.TempDir()
 		cfg := defaultTestRegentConfig()
 		cfg.RollbackOnTestFailure = true
-		cfg.TestCommand = "false" // tests fail → triggers revert
+		cfg.TestCommand = failingCommand() // tests fail → triggers revert
 		events := make(chan loop.LogEntry, 128)
 		g := &mockGit{
 			branch:     "main",

--- a/internal/regent/state.go
+++ b/internal/regent/state.go
@@ -16,6 +16,7 @@ type State struct {
 	Iteration       int       `json:"iteration"`
 	ConsecutiveErrs int       `json:"consecutive_errors"`
 	LastOutputAt    time.Time `json:"last_output_at"`
+	Agent           string    `json:"agent"`
 	LastCommit      string    `json:"last_commit"`
 	TotalCostUSD    float64   `json:"total_cost_usd"`
 	Branch          string    `json:"branch"`

--- a/internal/regent/state_test.go
+++ b/internal/regent/state_test.go
@@ -19,6 +19,7 @@ func TestSaveAndLoadState(t *testing.T) {
 		Iteration:       7,
 		ConsecutiveErrs: 0,
 		LastOutputAt:    now,
+		Agent:           "codex",
 		LastCommit:      "abc1234",
 		TotalCostUSD:    1.42,
 		Branch:          "feat/test-branch",
@@ -51,6 +52,9 @@ func TestSaveAndLoadState(t *testing.T) {
 	}
 	if loaded.LastCommit != original.LastCommit {
 		t.Errorf("LastCommit = %q, want %q", loaded.LastCommit, original.LastCommit)
+	}
+	if loaded.Agent != original.Agent {
+		t.Errorf("Agent = %q, want %q", loaded.Agent, original.Agent)
 	}
 	if loaded.TotalCostUSD != original.TotalCostUSD {
 		t.Errorf("TotalCostUSD = %f, want %f", loaded.TotalCostUSD, original.TotalCostUSD)

--- a/internal/store/index.go
+++ b/internal/store/index.go
@@ -39,6 +39,7 @@ func (idx *fileIndex) onAppend(entry loop.LogEntry, lineOffset, lineLen int64) {
 			startOffset: lineOffset,
 			summary: IterationSummary{
 				Number:  entry.Iteration,
+				Agent:   entry.Agent,
 				Mode:    entry.Mode,
 				StartAt: entry.Timestamp,
 				Commit:  entry.Commit,
@@ -53,6 +54,9 @@ func (idx *fileIndex) onAppend(entry loop.LogEntry, lineOffset, lineLen int64) {
 		s.Duration = entry.Duration
 		s.Subtype = entry.Subtype
 		s.EndAt = entry.Timestamp
+		if entry.Agent != "" {
+			s.Agent = entry.Agent
+		}
 		if entry.Commit != "" {
 			s.Commit = entry.Commit
 		}

--- a/internal/store/jsonl.go
+++ b/internal/store/jsonl.go
@@ -32,6 +32,7 @@ type JSONL struct {
 	pos        int64 // current write position in the file
 	branch     string
 	lastCommit string
+	agent      string
 }
 
 // NewJSONL creates (or reopens) the session JSONL log in dir. dir is created
@@ -90,6 +91,9 @@ func (j *JSONL) Append(entry loop.LogEntry) error {
 	}
 	if entry.Commit != "" {
 		j.lastCommit = entry.Commit
+	}
+	if entry.Agent != "" {
+		j.agent = entry.Agent
 	}
 	return nil
 }
@@ -190,6 +194,7 @@ func (j *JSONL) SessionSummary() (SessionSummary, error) {
 	return SessionSummary{
 		SessionID:  j.sessionID,
 		StartedAt:  j.startedAt,
+		Agent:      j.agent,
 		TotalCost:  total,
 		Iterations: len(j.idx.summaries),
 		LastCommit: j.lastCommit,

--- a/internal/store/jsonl_test.go
+++ b/internal/store/jsonl_test.go
@@ -59,7 +59,7 @@ func TestAppendAndIterationLog(t *testing.T) {
 
 	now := time.Now()
 	entries := []loop.LogEntry{
-		{Kind: loop.LogIterStart, Timestamp: now, Iteration: 1, Mode: "build", Branch: "main"},
+		{Kind: loop.LogIterStart, Timestamp: now, Iteration: 1, Agent: "codex", Mode: "build", Branch: "main"},
 		{Kind: loop.LogToolUse, Timestamp: now, Iteration: 1, ToolName: "Read", ToolInput: "main.go"},
 		{Kind: loop.LogIterComplete, Timestamp: now, Iteration: 1, CostUSD: 0.05, Duration: 1.2, Subtype: "success"},
 	}
@@ -104,7 +104,7 @@ func TestIterations(t *testing.T) {
 	now := time.Now()
 	for i := 1; i <= 3; i++ {
 		_ = s.Append(loop.LogEntry{Kind: loop.LogIterStart, Iteration: i, Mode: "build", Branch: "main", Timestamp: now})
-		_ = s.Append(loop.LogEntry{Kind: loop.LogIterComplete, Iteration: i, CostUSD: float64(i) * 0.01, Duration: float64(i), Subtype: "success", Timestamp: now})
+		_ = s.Append(loop.LogEntry{Kind: loop.LogIterComplete, Iteration: i, Agent: "claude", CostUSD: float64(i) * 0.01, Duration: float64(i), Subtype: "success", Timestamp: now})
 	}
 
 	iters, err := s.Iterations()
@@ -121,6 +121,9 @@ func TestIterations(t *testing.T) {
 		}
 		if it.Mode != "build" {
 			t.Errorf("iters[%d].Mode: expected build, got %q", i, it.Mode)
+		}
+		if it.Agent != "claude" {
+			t.Errorf("iters[%d].Agent: expected claude, got %q", i, it.Agent)
 		}
 		wantCost := float64(wantNum) * 0.01
 		if it.CostUSD != wantCost {
@@ -162,10 +165,10 @@ func TestSessionSummary(t *testing.T) {
 	defer func() { _ = s.Close() }()
 
 	now := time.Now()
-	_ = s.Append(loop.LogEntry{Kind: loop.LogInfo, Branch: "feat/test", Commit: "abc123", Timestamp: now})
-	_ = s.Append(loop.LogEntry{Kind: loop.LogIterStart, Iteration: 1, Timestamp: now})
+	_ = s.Append(loop.LogEntry{Kind: loop.LogInfo, Agent: "codex", Branch: "feat/test", Commit: "abc123", Timestamp: now})
+	_ = s.Append(loop.LogEntry{Kind: loop.LogIterStart, Iteration: 1, Agent: "codex", Timestamp: now})
 	_ = s.Append(loop.LogEntry{Kind: loop.LogIterComplete, Iteration: 1, CostUSD: 1.0, Timestamp: now})
-	_ = s.Append(loop.LogEntry{Kind: loop.LogIterStart, Iteration: 2, Timestamp: now})
+	_ = s.Append(loop.LogEntry{Kind: loop.LogIterStart, Iteration: 2, Agent: "codex", Timestamp: now})
 	_ = s.Append(loop.LogEntry{Kind: loop.LogIterComplete, Iteration: 2, CostUSD: 2.0, Timestamp: now})
 
 	sum, err := s.SessionSummary()
@@ -180,6 +183,9 @@ func TestSessionSummary(t *testing.T) {
 	}
 	if sum.Branch != "feat/test" {
 		t.Errorf("Branch: expected %q, got %q", "feat/test", sum.Branch)
+	}
+	if sum.Agent != "codex" {
+		t.Errorf("Agent: expected %q, got %q", "codex", sum.Agent)
 	}
 	if sum.LastCommit != "abc123" {
 		t.Errorf("LastCommit: expected %q, got %q", "abc123", sum.LastCommit)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -34,6 +34,7 @@ type Store interface {
 // IterationSummary summarises one completed loop iteration.
 type IterationSummary struct {
 	Number   int
+	Agent    string
 	Mode     string
 	CostUSD  float64
 	Duration float64
@@ -46,6 +47,7 @@ type IterationSummary struct {
 // SessionSummary summarises the current session.
 type SessionSummary struct {
 	SessionID  string
+	Agent      string
 	StartedAt  time.Time
 	TotalCost  float64
 	Iterations int

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -43,6 +43,7 @@ type Model struct {
 	loopState  LoopState
 	iteration  int
 	maxIter    int
+	agent      string
 	mode       string
 	branch     string
 	totalCost  float64
@@ -407,6 +408,9 @@ func (m Model) handleLogEntry(msg logEntryMsg) (tea.Model, tea.Cmd) {
 	if entry.Mode != "" {
 		m.mode = entry.Mode
 	}
+	if entry.Agent != "" {
+		m.agent = entry.Agent
+	}
 	if entry.MaxIter > 0 {
 		m.maxIter = entry.MaxIter
 	}
@@ -439,6 +443,7 @@ func (m Model) handleLogEntry(msg logEntryMsg) (tea.Model, tea.Cmd) {
 		m.totalCost += entry.CostUSD
 		summary := store.IterationSummary{
 			Number:   entry.Iteration,
+			Agent:    entry.Agent,
 			Mode:     entry.Mode,
 			CostUSD:  entry.CostUSD,
 			Duration: entry.Duration,
@@ -731,6 +736,7 @@ func (m Model) View() string {
 		ProjectName: m.projectName,
 		WorkDir:     m.workDir,
 		Branch:      m.branch,
+		Agent:       m.agent,
 		Mode:        m.mode,
 		Iteration:   m.iteration,
 		MaxIter:     m.maxIter,

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -201,6 +201,7 @@ func TestUpdate_LogEntry_MetadataExtracted(t *testing.T) {
 		Timestamp: time.Now(),
 		Iteration: 3,
 		MaxIter:   10,
+		Agent:     "codex",
 		Branch:    "feat/test",
 		Mode:      "build",
 		TotalCost: 0.05,
@@ -216,6 +217,9 @@ func TestUpdate_LogEntry_MetadataExtracted(t *testing.T) {
 	}
 	if m2.mode != "build" {
 		t.Errorf("mode = %q, want \"build\"", m2.mode)
+	}
+	if m2.agent != "codex" {
+		t.Errorf("agent = %q, want \"codex\"", m2.agent)
 	}
 }
 

--- a/internal/tui/panels/header.go
+++ b/internal/tui/panels/header.go
@@ -16,6 +16,7 @@ type HeaderProps struct {
 	ProjectName string
 	WorkDir     string
 	Branch      string
+	Agent       string
 	Mode        string
 	Iteration   int
 	MaxIter     int
@@ -94,6 +95,9 @@ func RenderHeader(props HeaderProps, width int, accentStyle lipgloss.Style) stri
 	parts := []string{"👑 " + name}
 	if props.WorkDir != "" {
 		parts = append(parts, "dir: "+AbbreviatePath(props.WorkDir))
+	}
+	if props.Agent != "" {
+		parts = append(parts, "agent: "+props.Agent)
 	}
 
 	stateLabel := props.StateLabel

--- a/ralph.toml
+++ b/ralph.toml
@@ -4,10 +4,16 @@
 [project]
 name = "RalphSpec"
 
+[agent]
+type = "claude"
+
 [claude]
 model = "sonnet"
 max_turns = 0  # 0 = unlimited agentic turns per iteration
 danger_skip_permissions = true
+
+[codex]
+model = ""
 
 [plan]
 prompt_file = "PLAN.md"

--- a/specs/010-codex-support/checklists/requirements.md
+++ b/specs/010-codex-support/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Codex Agent Support
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on the initial draft.
+- The spec scopes Codex support to Ralph's existing core workflows and keeps current default-agent behavior unchanged unless Codex is explicitly selected.

--- a/specs/010-codex-support/contracts/cli-agent-selection.md
+++ b/specs/010-codex-support/contracts/cli-agent-selection.md
@@ -1,0 +1,64 @@
+# Contract: CLI and Config Agent Selection
+
+## Project Configuration
+
+```toml
+[agent]
+type = "claude"
+
+[claude]
+model = "sonnet"
+max_turns = 0
+danger_skip_permissions = true
+
+[codex]
+model = ""
+```
+
+## Supported Values
+
+| Setting | Allowed values | Notes |
+|---------|----------------|-------|
+| `[agent].type` | `claude`, `codex` | Defaults to `claude` when omitted |
+| `[codex].model` | any non-empty string or empty | Empty defers to Codex CLI default |
+
+Unknown agent values are configuration errors.
+
+## Supported Commands
+
+The initial release supports `--agent <name>` on single-run loop entry points:
+
+| Command | Supported values | Behavior |
+|---------|------------------|----------|
+| `ralph build --agent <name>` | `claude`, `codex` | Overrides project default for one build run |
+| `ralph loop build --agent <name>` | `claude`, `codex` | Overrides project default for one build run |
+| `ralph loop plan --agent <name>` | `claude`, `codex` | Overrides project default for one plan run |
+| `ralph loop run --agent <name>` | `claude`, `codex` | Uses the selected agent for the composed single-run plan/build flow |
+
+## Unsupported Combinations
+
+| Invocation | Expected result |
+|------------|-----------------|
+| `ralph build --worktree --agent codex` | Fail before startup with an unsupported-workflow error |
+| Dashboard-triggered loop starts with effective agent `codex` | Fail before startup with an unsupported-workflow error |
+| Orchestrator/worktree-managed Codex launches | Fail before startup with an unsupported-workflow error |
+
+## Precedence Rules
+
+1. `--agent` flag, if present
+2. `[agent].type` project default
+3. Built-in default: `claude`
+
+## Visibility Requirements
+
+- The resolved effective agent must appear in structured loop events.
+- Session summaries and Regent state must persist the effective agent.
+- User-facing live output/status views must show the effective agent for the run.
+
+## Error Contract
+
+Codex startup failures must be actionable. Examples:
+
+- `codex agent unavailable: codex executable not found on PATH`
+- `codex agent unsupported for worktree mode`
+- `config validation: agent.type must be one of claude,codex`

--- a/specs/010-codex-support/contracts/cli-agent-selection.md
+++ b/specs/010-codex-support/contracts/cli-agent-selection.md
@@ -39,8 +39,8 @@ The initial release supports `--agent <name>` on single-run loop entry points:
 
 | Invocation | Expected result |
 |------------|-----------------|
-| `ralph build --worktree --agent codex` | Fail before startup with an unsupported-workflow error |
-| Dashboard-triggered loop starts with effective agent `codex` | Fail before startup with an unsupported-workflow error |
+| `ralph build --worktree --agent codex` | Fail before startup with an unsupported-workflow error and Claude fallback guidance |
+| Dashboard-triggered loop starts with effective agent `codex` | Fail before startup with an unsupported-workflow error and direct no-TUI guidance |
 | Orchestrator/worktree-managed Codex launches | Fail before startup with an unsupported-workflow error |
 
 ## Precedence Rules
@@ -52,6 +52,7 @@ The initial release supports `--agent <name>` on single-run loop entry points:
 ## Visibility Requirements
 
 - The resolved effective agent must appear in structured loop events.
+- Plain no-TUI output must visibly identify the effective agent during the run.
 - Session summaries and Regent state must persist the effective agent.
 - User-facing live output/status views must show the effective agent for the run.
 
@@ -59,6 +60,7 @@ The initial release supports `--agent <name>` on single-run loop entry points:
 
 Codex startup failures must be actionable. Examples:
 
-- `codex agent unavailable: codex executable not found on PATH`
-- `codex agent unsupported for worktree mode`
+- `codex agent unavailable: codex executable not found on PATH; install or log into Codex CLI, or use --agent claude`
+- `codex agent unsupported for worktree mode; use --agent claude or omit --worktree`
+- `codex agent unsupported for dashboard mode; start Codex with ralph build --agent codex --no-tui or use claude in the dashboard`
 - `config validation: agent.type must be one of claude,codex`

--- a/specs/010-codex-support/data-model.md
+++ b/specs/010-codex-support/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Codex Agent Support
+
+## AgentSelection
+
+Represents how Ralph chooses the effective agent for a run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ProjectDefault` | `string` | Saved project-level agent from `[agent] type` |
+| `Override` | `string` | Optional per-run `--agent` value |
+| `Effective` | `string` | Resolved agent for the run |
+| `Source` | `string` | Resolution source: `project-default` or `flag` |
+
+**Validation rules**:
+- Supported values are `claude` and `codex`.
+- Empty override means use `ProjectDefault`.
+- Unknown values fail validation before loop startup.
+
+## CodexConfig
+
+Minimal configuration for the Codex adapter.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Model` | `string` | `""` | Optional Codex model override; empty means use Codex CLI default |
+
+## AgentRunRecord
+
+Persisted session-level metadata describing which agent produced a run.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Agent` | `string` | Effective agent for the session |
+| `Mode` | `string` | Loop mode (`plan`, `build`, or supported composed flow) |
+| `Branch` | `string` | Git branch for the run |
+| `LastCommit` | `string` | Latest commit observed during the session |
+| `StartedAt` | `time` | Session start time |
+| `FinishedAt` | `time` | Session end time |
+| `TotalCostUSD` | `float64` | Accumulated reported cost |
+| `Passed` | `bool` | Final success state recorded by Regent/state tracking |
+
+**Backed by**:
+- `loop.LogEntry.Agent`
+- `store.IterationSummary.Agent`
+- `store.SessionSummary.Agent`
+- `regent.State.Agent`
+
+## CodexSessionState
+
+Ephemeral validation state used before loop startup.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Selected` | `string` | Requested effective agent |
+| `Available` | `bool` | Whether the selected binary is present and runnable |
+| `SupportedFlow` | `bool` | Whether the current Ralph command/path supports the selected agent |
+| `ValidationError` | `string` | Actionable failure reason when startup is rejected |
+
+## State Transitions
+
+```text
+Selected -> Validated -> Running -> Completed
+                    \-> RejectedUnsupported
+                    \-> RejectedUnavailable
+                    \-> Failed
+```
+
+- `RejectedUnsupported`: Codex chosen for worktree, dashboard-started, or orchestrator-managed flow.
+- `RejectedUnavailable`: Codex binary missing, login/setup invalid, or startup command fails validation.
+- `Failed`: Loop started but agent run returned an execution error.

--- a/specs/010-codex-support/plan.md
+++ b/specs/010-codex-support/plan.md
@@ -1,0 +1,188 @@
+# Implementation Plan: Codex Agent Support
+
+**Branch**: `010-codex-support` | **Date**: 2026-04-18 | **Spec**: `specs/010-codex-support/spec.md`
+**Input**: Feature specification from `specs/010-codex-support/spec.md`
+
+## Summary
+
+Add Codex as an opt-in agent for Ralph's main single-run plan/build workflows by introducing explicit agent selection, a Codex CLI adapter, and persisted agent metadata across loop logs, session summaries, Regent state, and user-visible status output. Preserve Claude as the default agent, reuse the existing loop/Regent/store plumbing, and fail fast for unsupported Codex workflows such as worktree orchestration and dashboard-launched parallel flows.
+
+## Technical Context
+
+**Language/Version**: Go 1.24  
+**Primary Dependencies**: cobra, BurntSushi/toml, bubbletea, lipgloss, existing `internal/claude` event/interface types, external Codex CLI binary  
+**Storage**: `ralph.toml`, JSONL session logs in `.ralph/logs/`, Regent state in `.ralph/regent-state.json`  
+**Testing**: `go test ./...`, `go vet ./...`, table-driven unit tests for config, command parsing, adapter parsing, and selection precedence  
+**Target Platform**: darwin/arm64, darwin/amd64, linux/amd64, windows/amd64  
+**Project Type**: CLI tool with optional TUI  
+**Performance Goals**: Agent selection and availability validation complete before the first iteration begins; unsupported Codex flows fail immediately with actionable errors; agent metadata is visible in live and recorded runs with no extra operator steps  
+**Constraints**: Preserve existing Claude defaults; add no new Go dependencies unless parser requirements force it; keep Codex initial scope to single-run plan/build workflows; reject unsupported worktree/orchestrator/dashboard flows explicitly; maintain existing Regent, git, and session-log behavior across agents  
+**Scale/Scope**: One project-level default agent, one per-run override, one active single-run loop at a time; persisted agent identity for session and iteration history
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Driven | PASS | Spec 010 and clarification session define scope, selection model, and unsupported workflows. |
+| II. Supervised Autonomy | PASS | Plan preserves the Regent path and requires Codex to flow through the same supervision hooks as Claude. |
+| III. Test-Gated Commits | PASS | Work includes config, command, adapter, state, and visibility tests; no bypass of existing test-gated flow. |
+| IV. Idiomatic Go | PASS | Plan prefers a small new internal adapter package plus existing interfaces; no new external Go dependency is planned. |
+| V. Observable Loops | PASS | Agent identity becomes part of log/state/session metadata, removing silent ambiguity in mixed-agent histories. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-codex-support/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── cli-agent-selection.md
+└── tasks.md
+```
+
+### Source Code (affected files)
+
+```text
+cmd/ralph/
+├── commands.go              # Add per-run --agent override on supported loop commands
+├── execute.go               # Resolve effective agent, create adapter, reject unsupported Codex flows
+├── execute_test.go          # Selection precedence and unsupported-flow coverage
+├── main.go                  # Remove Claude-only startup messaging from generic loop paths
+└── wiring.go                # Surface agent identity in single-run TUI paths; reject dashboard Codex launches
+
+internal/claude/
+├── claude.go                # Keep shared agent interface/events for initial release
+
+internal/codex/
+├── agent.go                 # Codex CLI adapter implementing the shared agent interface
+├── parser.go                # Map `codex exec --json` JSONL events into shared loop events
+└── parser_test.go           # Parser and startup/failure coverage
+
+internal/config/
+├── config.go                # Add [agent] and [codex] config sections plus validation/defaults
+├── config_test.go           # Supported values, defaults, and validation errors
+└── scaffold.go              # Scaffold new config keys into generated ralph.toml
+
+internal/loop/
+├── loop.go                  # Remove Claude-specific messages/config access; emit agent-aware entries
+├── event.go                 # Add agent identity to structured log entries
+└── loop_test.go             # Agent-agnostic loop messaging and metadata coverage
+
+internal/store/
+├── store.go                 # Add agent identity to summaries
+├── jsonl.go                 # Persist and return agent-aware session data
+└── jsonl_test.go            # Session/iteration metadata coverage
+
+internal/regent/
+├── state.go                 # Persist effective agent in regent state
+└── state_test.go            # State round-trip coverage
+
+internal/tui/
+├── app.go                   # Show selected agent in live session context
+└── panels/
+    └── header.go            # Render active agent in header/status area
+
+README.md                    # Document Codex as supported and describe selection/setup
+ralph.toml                   # New [agent] and [codex] settings in examples/tests
+```
+
+**Structure Decision**: Preserve the existing command/loop/store/regent architecture. Add one small `internal/codex/` adapter package rather than renaming broad shared plumbing now. Keep the shared agent/event interface in `internal/claude/` for this release to minimize churn, while making loop execution and user-visible metadata agent-agnostic.
+
+## Phase 0: Research
+
+### R-001: Agent Selection Contract
+
+**Decision**: Use a project-level `[agent]` section with `type = "claude" | "codex"` plus a repeatable per-run `--agent` flag on supported loop entry points. Per-run selection overrides the project default for that run only.
+
+**Rationale**: This matches the clarified spec, keeps existing projects unchanged by default, and makes precedence explicit and testable in one place.
+
+**Alternatives considered**:
+- Reusing `[project]` for agent selection: mixes unrelated concerns and weakens validation.
+- Environment-variable-only selection: not discoverable or durable enough for project defaults.
+- Separate commands such as `ralph codex build`: duplicates command surface and fragments tests.
+
+### R-002: Codex Runtime Invocation
+
+**Decision**: Run Codex through `codex exec --json --full-auto --cd <dir> [--model <model>] <prompt>` and translate the emitted JSONL stream into the existing shared event model.
+
+**Rationale**: `codex exec` is the non-interactive Codex path, `--json` provides machine-readable events, `--cd` aligns the subprocess working root with Ralph's loop directory, and `--full-auto` enables autonomous execution without resorting to the more dangerous sandbox-bypass flag.
+
+**Alternatives considered**:
+- Interactive `codex` TUI mode: not appropriate for Ralph's autonomous loop.
+- `--dangerously-bypass-approvals-and-sandbox`: lower friction but violates the repo's safety posture.
+- Direct API integration: larger dependency and auth surface than needed for the first release.
+
+### R-003: Shared Interface Strategy
+
+**Decision**: Keep the existing `internal/claude.Agent` interface and shared event types for the initial release, and add `internal/codex.Agent` as another implementation of that interface.
+
+**Rationale**: The interface seam already exists and the loop depends on it. A broad rename from `internal/claude` to a new generic package would create documentation and code churn that is unnecessary for initial Codex support.
+
+**Alternatives considered**:
+- Renaming `internal/claude` to a new generic package immediately: cleaner long-term, but high churn across the codebase and constitution references.
+- Duplicating loop execution for Codex: would split logic for logging, git, and Regent behavior.
+
+### R-004: Persisted Agent Identity
+
+**Decision**: Add an `Agent` field to `loop.LogEntry`, `store.IterationSummary`, `store.SessionSummary`, and `regent.State`, and surface it in status/TUI output.
+
+**Rationale**: The spec requires operators to distinguish live and historical runs by agent. Persisting the effective agent in the primary data structures is more reliable than inferring it later from config or branch state.
+
+**Alternatives considered**:
+- Inferring the agent from current config: incorrect for historical sessions after config changes.
+- Showing agent only in transient console output: fails the observability requirement for stored sessions.
+
+### R-005: Unsupported Workflow Handling
+
+**Decision**: Explicitly reject Codex in workflows outside the initial release scope: worktree mode, orchestrator-managed parallel agents, and dashboard-launched loop starts. Speckit commands remain separate from this feature.
+
+**Rationale**: The current worktree/orchestrator code still hard-codes Claude. An explicit error is safer and clearer than a partial or silent fallback.
+
+**Alternatives considered**:
+- Silent fallback to Claude: violates the clarified selection model and obscures operator intent.
+- Partial support in some advanced flows: hard to test and easy to regress.
+
+### R-006: Codex Config Scope
+
+**Decision**: Add a minimal `[codex]` section with `model = ""` for the initial release and rely on Codex CLI defaults for sandbox/approval behavior beyond Ralph's fixed `--full-auto` invocation.
+
+**Rationale**: This keeps the first release small while still allowing developers to pick a Codex model explicitly when needed.
+
+**Alternatives considered**:
+- Mirroring every Codex CLI option in `ralph.toml`: too large for the initial release.
+- No Codex config section at all: makes model selection harder and limits future extension.
+
+## Phase 1: Data Model & Contracts
+
+### Data Model
+
+See `specs/010-codex-support/data-model.md`.
+
+### Contracts
+
+See `specs/010-codex-support/contracts/cli-agent-selection.md`.
+
+### Quickstart
+
+See `specs/010-codex-support/quickstart.md`.
+
+## Post-Design Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Spec-Driven | PASS | Design artifacts trace directly to spec requirements and clarifications. |
+| II. Supervised Autonomy | PASS | Both adapters converge on the same loop, store, and Regent paths. |
+| III. Test-Gated Commits | PASS | Planned test matrix covers selection, parser behavior, unsupported-flow rejection, and state persistence. |
+| IV. Idiomatic Go | PASS | One new internal package, no planned external dependency additions, explicit validation/errors. |
+| V. Observable Loops | PASS | Agent identity is stored and rendered in both live and persisted views. |
+
+## Complexity Tracking
+
+No constitution violations requiring justification.

--- a/specs/010-codex-support/plan.md
+++ b/specs/010-codex-support/plan.md
@@ -1,188 +1,104 @@
-# Implementation Plan: Codex Agent Support
+# Implementation Plan: [FEATURE]
 
-**Branch**: `010-codex-support` | **Date**: 2026-04-18 | **Spec**: `specs/010-codex-support/spec.md`
-**Input**: Feature specification from `specs/010-codex-support/spec.md`
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-Add Codex as an opt-in agent for Ralph's main single-run plan/build workflows by introducing explicit agent selection, a Codex CLI adapter, and persisted agent metadata across loop logs, session summaries, Regent state, and user-visible status output. Preserve Claude as the default agent, reuse the existing loop/Regent/store plumbing, and fail fast for unsupported Codex workflows such as worktree orchestration and dashboard-launched parallel flows.
+[Extract from feature spec: primary requirement + technical approach from research]
 
 ## Technical Context
 
-**Language/Version**: Go 1.24  
-**Primary Dependencies**: cobra, BurntSushi/toml, bubbletea, lipgloss, existing `internal/claude` event/interface types, external Codex CLI binary  
-**Storage**: `ralph.toml`, JSONL session logs in `.ralph/logs/`, Regent state in `.ralph/regent-state.json`  
-**Testing**: `go test ./...`, `go vet ./...`, table-driven unit tests for config, command parsing, adapter parsing, and selection precedence  
-**Target Platform**: darwin/arm64, darwin/amd64, linux/amd64, windows/amd64  
-**Project Type**: CLI tool with optional TUI  
-**Performance Goals**: Agent selection and availability validation complete before the first iteration begins; unsupported Codex flows fail immediately with actionable errors; agent metadata is visible in live and recorded runs with no extra operator steps  
-**Constraints**: Preserve existing Claude defaults; add no new Go dependencies unless parser requirements force it; keep Codex initial scope to single-run plan/build workflows; reject unsupported worktree/orchestrator/dashboard flows explicitly; maintain existing Regent, git, and session-log behavior across agents  
-**Scale/Scope**: One project-level default agent, one per-run override, one active single-run loop at a time; persisted agent identity for session and iteration history
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
 
-| Principle | Status | Notes |
-|-----------|--------|-------|
-| I. Spec-Driven | PASS | Spec 010 and clarification session define scope, selection model, and unsupported workflows. |
-| II. Supervised Autonomy | PASS | Plan preserves the Regent path and requires Codex to flow through the same supervision hooks as Claude. |
-| III. Test-Gated Commits | PASS | Work includes config, command, adapter, state, and visibility tests; no bypass of existing test-gated flow. |
-| IV. Idiomatic Go | PASS | Plan prefers a small new internal adapter package plus existing interfaces; no new external Go dependency is planned. |
-| V. Observable Loops | PASS | Agent identity becomes part of log/state/session metadata, removing silent ambiguity in mixed-agent histories. |
+[Gates determined based on constitution file]
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/010-codex-support/
-├── spec.md
-├── plan.md
-├── research.md
-├── data-model.md
-├── quickstart.md
-├── contracts/
-│   └── cli-agent-selection.md
-└── tasks.md
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
 ```
 
-### Source Code (affected files)
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
 
 ```text
-cmd/ralph/
-├── commands.go              # Add per-run --agent override on supported loop commands
-├── execute.go               # Resolve effective agent, create adapter, reject unsupported Codex flows
-├── execute_test.go          # Selection precedence and unsupported-flow coverage
-├── main.go                  # Remove Claude-only startup messaging from generic loop paths
-└── wiring.go                # Surface agent identity in single-run TUI paths; reject dashboard Codex launches
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
 
-internal/claude/
-├── claude.go                # Keep shared agent interface/events for initial release
+tests/
+├── contract/
+├── integration/
+└── unit/
 
-internal/codex/
-├── agent.go                 # Codex CLI adapter implementing the shared agent interface
-├── parser.go                # Map `codex exec --json` JSONL events into shared loop events
-└── parser_test.go           # Parser and startup/failure coverage
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
 
-internal/config/
-├── config.go                # Add [agent] and [codex] config sections plus validation/defaults
-├── config_test.go           # Supported values, defaults, and validation errors
-└── scaffold.go              # Scaffold new config keys into generated ralph.toml
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
 
-internal/loop/
-├── loop.go                  # Remove Claude-specific messages/config access; emit agent-aware entries
-├── event.go                 # Add agent identity to structured log entries
-└── loop_test.go             # Agent-agnostic loop messaging and metadata coverage
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
 
-internal/store/
-├── store.go                 # Add agent identity to summaries
-├── jsonl.go                 # Persist and return agent-aware session data
-└── jsonl_test.go            # Session/iteration metadata coverage
-
-internal/regent/
-├── state.go                 # Persist effective agent in regent state
-└── state_test.go            # State round-trip coverage
-
-internal/tui/
-├── app.go                   # Show selected agent in live session context
-└── panels/
-    └── header.go            # Render active agent in header/status area
-
-README.md                    # Document Codex as supported and describe selection/setup
-ralph.toml                   # New [agent] and [codex] settings in examples/tests
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
 ```
 
-**Structure Decision**: Preserve the existing command/loop/store/regent architecture. Add one small `internal/codex/` adapter package rather than renaming broad shared plumbing now. Keep the shared agent/event interface in `internal/claude/` for this release to minimize churn, while making loop execution and user-visible metadata agent-agnostic.
-
-## Phase 0: Research
-
-### R-001: Agent Selection Contract
-
-**Decision**: Use a project-level `[agent]` section with `type = "claude" | "codex"` plus a repeatable per-run `--agent` flag on supported loop entry points. Per-run selection overrides the project default for that run only.
-
-**Rationale**: This matches the clarified spec, keeps existing projects unchanged by default, and makes precedence explicit and testable in one place.
-
-**Alternatives considered**:
-- Reusing `[project]` for agent selection: mixes unrelated concerns and weakens validation.
-- Environment-variable-only selection: not discoverable or durable enough for project defaults.
-- Separate commands such as `ralph codex build`: duplicates command surface and fragments tests.
-
-### R-002: Codex Runtime Invocation
-
-**Decision**: Run Codex through `codex exec --json --full-auto --cd <dir> [--model <model>] <prompt>` and translate the emitted JSONL stream into the existing shared event model.
-
-**Rationale**: `codex exec` is the non-interactive Codex path, `--json` provides machine-readable events, `--cd` aligns the subprocess working root with Ralph's loop directory, and `--full-auto` enables autonomous execution without resorting to the more dangerous sandbox-bypass flag.
-
-**Alternatives considered**:
-- Interactive `codex` TUI mode: not appropriate for Ralph's autonomous loop.
-- `--dangerously-bypass-approvals-and-sandbox`: lower friction but violates the repo's safety posture.
-- Direct API integration: larger dependency and auth surface than needed for the first release.
-
-### R-003: Shared Interface Strategy
-
-**Decision**: Keep the existing `internal/claude.Agent` interface and shared event types for the initial release, and add `internal/codex.Agent` as another implementation of that interface.
-
-**Rationale**: The interface seam already exists and the loop depends on it. A broad rename from `internal/claude` to a new generic package would create documentation and code churn that is unnecessary for initial Codex support.
-
-**Alternatives considered**:
-- Renaming `internal/claude` to a new generic package immediately: cleaner long-term, but high churn across the codebase and constitution references.
-- Duplicating loop execution for Codex: would split logic for logging, git, and Regent behavior.
-
-### R-004: Persisted Agent Identity
-
-**Decision**: Add an `Agent` field to `loop.LogEntry`, `store.IterationSummary`, `store.SessionSummary`, and `regent.State`, and surface it in status/TUI output.
-
-**Rationale**: The spec requires operators to distinguish live and historical runs by agent. Persisting the effective agent in the primary data structures is more reliable than inferring it later from config or branch state.
-
-**Alternatives considered**:
-- Inferring the agent from current config: incorrect for historical sessions after config changes.
-- Showing agent only in transient console output: fails the observability requirement for stored sessions.
-
-### R-005: Unsupported Workflow Handling
-
-**Decision**: Explicitly reject Codex in workflows outside the initial release scope: worktree mode, orchestrator-managed parallel agents, and dashboard-launched loop starts. Speckit commands remain separate from this feature.
-
-**Rationale**: The current worktree/orchestrator code still hard-codes Claude. An explicit error is safer and clearer than a partial or silent fallback.
-
-**Alternatives considered**:
-- Silent fallback to Claude: violates the clarified selection model and obscures operator intent.
-- Partial support in some advanced flows: hard to test and easy to regress.
-
-### R-006: Codex Config Scope
-
-**Decision**: Add a minimal `[codex]` section with `model = ""` for the initial release and rely on Codex CLI defaults for sandbox/approval behavior beyond Ralph's fixed `--full-auto` invocation.
-
-**Rationale**: This keeps the first release small while still allowing developers to pick a Codex model explicitly when needed.
-
-**Alternatives considered**:
-- Mirroring every Codex CLI option in `ralph.toml`: too large for the initial release.
-- No Codex config section at all: makes model selection harder and limits future extension.
-
-## Phase 1: Data Model & Contracts
-
-### Data Model
-
-See `specs/010-codex-support/data-model.md`.
-
-### Contracts
-
-See `specs/010-codex-support/contracts/cli-agent-selection.md`.
-
-### Quickstart
-
-See `specs/010-codex-support/quickstart.md`.
-
-## Post-Design Constitution Check
-
-| Principle | Status | Notes |
-|-----------|--------|-------|
-| I. Spec-Driven | PASS | Design artifacts trace directly to spec requirements and clarifications. |
-| II. Supervised Autonomy | PASS | Both adapters converge on the same loop, store, and Regent paths. |
-| III. Test-Gated Commits | PASS | Planned test matrix covers selection, parser behavior, unsupported-flow rejection, and state persistence. |
-| IV. Idiomatic Go | PASS | One new internal package, no planned external dependency additions, explicit validation/errors. |
-| V. Observable Loops | PASS | Agent identity is stored and rendered in both live and persisted views. |
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
 
 ## Complexity Tracking
 
-No constitution violations requiring justification.
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/010-codex-support/quickstart.md
+++ b/specs/010-codex-support/quickstart.md
@@ -32,13 +32,23 @@ ralph loop run --agent codex --no-tui
 Expected behavior:
 - Ralph resolves `codex` as the effective agent
 - Startup validates Codex availability before the first iteration
-- Live output and stored session metadata identify Codex as the active agent
+- Plain live output includes a `[codex]` prefix on loop events
+- Stored session metadata identifies Codex as the active agent
 
 ## 4. Verify persisted metadata
 
 - Inspect `.ralph/regent-state.json` for the recorded agent
 - Inspect the latest JSONL session log in `.ralph/logs/`
 - Confirm `ralph status` or TUI status surfaces the selected agent
+
+Example status excerpt:
+
+```text
+Ralph Status
+  Agent:               codex
+  Branch:              test-branch
+  Mode:                build
+```
 
 ## 5. Verify unsupported scope is rejected cleanly
 
@@ -49,3 +59,10 @@ ralph build --worktree --agent codex
 Expected behavior:
 - Ralph exits before starting work
 - The error explains that Codex worktree support is not part of the initial release
+- The error suggests using `--agent claude` or omitting `--worktree`
+
+Example error:
+
+```text
+codex agent unsupported for worktree mode; use --agent claude or omit --worktree
+```

--- a/specs/010-codex-support/quickstart.md
+++ b/specs/010-codex-support/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Codex Agent Support
+
+## 1. Ensure Codex CLI is available
+
+```powershell
+codex --help
+codex login
+```
+
+## 2. Select Codex for the project
+
+Add or update `ralph.toml`:
+
+```toml
+[agent]
+type = "codex"
+
+[codex]
+model = ""
+```
+
+## 3. Run a supported Codex flow
+
+Examples:
+
+```powershell
+ralph loop plan --agent codex --no-tui
+ralph build --agent codex --no-tui
+ralph loop run --agent codex --no-tui
+```
+
+Expected behavior:
+- Ralph resolves `codex` as the effective agent
+- Startup validates Codex availability before the first iteration
+- Live output and stored session metadata identify Codex as the active agent
+
+## 4. Verify persisted metadata
+
+- Inspect `.ralph/regent-state.json` for the recorded agent
+- Inspect the latest JSONL session log in `.ralph/logs/`
+- Confirm `ralph status` or TUI status surfaces the selected agent
+
+## 5. Verify unsupported scope is rejected cleanly
+
+```powershell
+ralph build --worktree --agent codex
+```
+
+Expected behavior:
+- Ralph exits before starting work
+- The error explains that Codex worktree support is not part of the initial release

--- a/specs/010-codex-support/research.md
+++ b/specs/010-codex-support/research.md
@@ -1,0 +1,63 @@
+# Research: Codex Agent Support
+
+## R-001: Agent Selection Contract
+
+**Decision**: Use `[agent] type = "claude" | "codex"` in `ralph.toml` and a per-run `--agent` flag on supported loop commands. The command-line flag overrides the project default for one run only.
+
+**Rationale**: This gives Ralph one canonical way to resolve the effective agent while keeping existing Claude-backed projects unchanged.
+
+**Alternatives considered**:
+- Environment-variable-only agent selection
+- Separate Codex-specific commands
+- Storing the agent under `[project]`
+
+## R-002: Codex Runtime Strategy
+
+**Decision**: Launch Codex with `codex exec --json --full-auto --cd <dir>` and optional `--model <model>`, then translate JSONL events into Ralph's shared event model.
+
+**Rationale**: The installed Codex CLI exposes a non-interactive `exec` mode with structured JSON output, which matches Ralph's loop architecture.
+
+**Alternatives considered**:
+- Interactive `codex` mode
+- Direct API integration
+- Disabling sandbox/approvals with the dangerous bypass flag
+
+## R-003: Interface Reuse vs Rename
+
+**Decision**: Reuse the existing shared `internal/claude.Agent` interface for this release and add a new `internal/codex` adapter package.
+
+**Rationale**: The loop already depends on the interface rather than the concrete Claude runner, so this is the smallest correct change.
+
+**Alternatives considered**:
+- Renaming the shared interface package immediately
+- Duplicating loop execution for Codex
+
+## R-004: Agent Metadata Persistence
+
+**Decision**: Persist the effective agent in loop log entries, session summaries, iteration summaries, and Regent state.
+
+**Rationale**: Historical session review must remain accurate after the project default changes.
+
+**Alternatives considered**:
+- Inferring agent identity from current config
+- Showing agent only in live console output
+
+## R-005: Unsupported Scope Handling
+
+**Decision**: Reject Codex for worktree mode, orchestrator-managed parallel flows, and dashboard-started loops until those paths are explicitly implemented.
+
+**Rationale**: Those paths still construct Claude directly today. Explicit rejection prevents ambiguous or misleading behavior.
+
+**Alternatives considered**:
+- Silent fallback to Claude
+- Partial support in advanced flows
+
+## R-006: Codex Configuration Scope
+
+**Decision**: Add a minimal `[codex]` config section with only `model = ""` in the initial release.
+
+**Rationale**: Ralph needs a small stable contract now; broader Codex tuning can be layered later if real demand appears.
+
+**Alternatives considered**:
+- Mirroring all Codex CLI options in config
+- No Codex-specific config at all

--- a/specs/010-codex-support/spec.md
+++ b/specs/010-codex-support/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Codex Agent Support
+
+**Feature Branch**: `010-codex-support`  
+**Created**: 2026-04-18  
+**Status**: Draft  
+**Input**: User description: "add support for codex"
+
+## Clarifications
+
+### Session 2026-04-18
+
+- Q: What is the initial Codex support scope? → A: Main runs first: project/run selection plus normal plan/build flows.
+- Q: How should developers choose Codex? → A: Both: project default plus explicit per-run override.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Run Ralph with Codex for Main Flows (Priority: P1)
+
+A developer wants to use Codex as Ralph's active coding agent for Ralph's main plan and build workflows without changing the rest of Ralph's supervision, git, and review flow. They select Codex, start a run, and Ralph completes the session while showing progress the same way it does for the existing default agent.
+
+**Why this priority**: This is the core user value of the feature. If a developer cannot successfully run Ralph with Codex in the main workflow, Codex support does not exist in any meaningful sense.
+
+**Independent Test**: Configure a project to use Codex, start a plan or build run, and verify the session begins, progress is visible, and the run completes with the same end-to-end workflow expectations as the existing agent path.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer has selected Codex as the active agent and Codex is available for use, **When** they start a Ralph plan or build run, **Then** Ralph starts the session with Codex and streams progress, results, and completion state through the normal Ralph workflow.
+2. **Given** a Codex-backed run produces changes that require Ralph's normal validation steps, **When** the run completes an iteration, **Then** Ralph applies the same supervision, git, and test-gated behavior used for other supported agents.
+
+---
+
+### User Story 2 - Choose the Agent Per Project or Run (Priority: P2)
+
+A developer wants to decide which supported agent Ralph should use for a given project or invocation. They can keep the existing default agent for one project, choose Codex for another, or override the choice for a single run without rewriting the rest of their workflow.
+
+**Why this priority**: Codex support is only practical if developers can intentionally select it. Clear agent selection also avoids accidental behavior changes for existing Claude-based projects.
+
+**Independent Test**: Set one project or run to use Codex and another to use the existing default agent, then verify each run uses the selected agent and reports that choice clearly before work begins.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project is configured to use Codex by default, **When** a developer starts Ralph without additional overrides, **Then** Ralph uses Codex for that run.
+2. **Given** a project defaults to another supported agent, **When** a developer explicitly chooses Codex for a single run, **Then** Ralph uses Codex only for that run and leaves the project's default setting unchanged.
+3. **Given** a developer opens Ralph's dashboard or reviews run output, **When** a run is active or completed, **Then** the selected agent is visible so the developer can distinguish Codex sessions from other agent sessions.
+
+---
+
+### User Story 3 - Recover Quickly from Setup or Compatibility Problems (Priority: P3)
+
+A developer tries to use Codex before it is installed, authenticated, or configured correctly. Instead of failing silently or with a generic subprocess error, Ralph explains what is wrong and what the developer needs to fix before retrying.
+
+**Why this priority**: Agent support is incomplete if failures are opaque. Clear setup and compatibility feedback reduces support burden and makes the feature usable by developers who are trying Codex for the first time.
+
+**Independent Test**: Attempt to start a Codex-backed run in an environment where Codex is unavailable or misconfigured and verify Ralph exits early with an actionable message that identifies the problem and the next step.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer selects Codex but Codex is not available in the environment, **When** they start a run, **Then** Ralph stops before beginning work and shows an actionable setup error.
+2. **Given** a developer selects Codex with an unsupported or invalid agent setting, **When** Ralph validates the run configuration, **Then** Ralph rejects the run with a clear explanation of what must be corrected.
+
+---
+
+### Edge Cases
+
+- What happens when a project does not choose an agent explicitly? Ralph continues using the existing default agent so current projects do not change behavior unexpectedly.
+- What happens when a developer selects Codex for a run while another project still uses the existing default agent? Each run uses its own explicit selection without leaking that choice across projects.
+- What happens when Codex becomes unavailable after selection but before work starts? Ralph fails fast with a clear error before entering the main iteration loop.
+- What happens when a developer reviews historical runs from multiple agents? Ralph shows which agent produced each run so results remain understandable.
+- What happens when a developer attempts to use Codex in a workflow outside the initial release scope? Ralph clearly reports that Codex is not yet available for that workflow instead of silently falling back or partially running.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Ralph MUST support Codex as a first-class selectable agent for Ralph's main plan and build workflows in the initial release.
+- **FR-002**: Ralph MUST allow Codex to be selected as the saved default agent for a project.
+- **FR-003**: Ralph MUST allow Codex to be selected for an individual run without changing the project's saved default agent.
+- **FR-004**: Ralph MUST preserve existing behavior for projects that do not opt into Codex.
+- **FR-005**: Ralph MUST display the selected agent before or during a run so the operator can verify which agent is active.
+- **FR-006**: Ralph MUST keep Ralph's existing supervision, logging, git, and post-run validation behavior consistent regardless of whether the active agent is Codex or the existing default agent.
+- **FR-007**: Ralph MUST validate that Codex is available and usable before starting a Codex-backed run.
+- **FR-008**: Ralph MUST provide actionable error messages when Codex cannot be started, is not configured correctly, or is otherwise unavailable.
+- **FR-009**: Ralph MUST record which agent produced a run so live views and historical run review remain understandable.
+- **FR-010**: Ralph MUST clearly reject attempts to use Codex in workflows that are outside the initial release scope.
+- **FR-013**: Ralph MUST keep unsupported Codex workflows out of scope for the initial release, including parallel-agent, worktree, and other advanced run modes until they are explicitly added in a later feature.
+- **FR-011**: Ralph MUST reject invalid agent selections with a clear validation error rather than silently falling back to a different agent.
+- **FR-012**: Ralph MUST document Codex as a supported agent, including how a developer selects it and what prerequisites are required.
+- **FR-014**: Ralph MUST define a clear precedence rule where an explicit per-run agent selection overrides the project's saved default for that run only.
+
+### Key Entities *(include if feature involves data)*
+
+- **Agent Selection**: The developer's chosen agent for a project or a single run. Determines which supported agent Ralph will launch while preserving the rest of the Ralph workflow.
+- **Project Agent Default**: The saved agent preference used when a run starts without an explicit override.
+- **Agent Profile**: The saved configuration associated with a supported agent, including any agent-specific defaults or validation rules required before a run can start.
+- **Agent Run Record**: The session metadata that identifies which agent performed a given run so operators can interpret live output, history, and troubleshooting information correctly.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer who has Codex available can switch a project to Codex and start a successful Ralph plan or build run in under 2 minutes without changing unrelated workflow settings.
+- **SC-002**: In acceptance testing, 100% of existing projects that do not opt into Codex continue to use their prior default agent with no behavior change.
+- **SC-003**: In acceptance testing, 90% of first-time Codex users can identify and correct missing setup from Ralph's error guidance without needing to inspect source code or external support.
+- **SC-004**: Operators can identify the active agent for 100% of live and recorded runs from Ralph's normal UI or run output.
+
+## Assumptions
+
+- Codex support is additive and opt-in; the current default agent remains the default unless a project or run explicitly selects Codex.
+- Developers using Codex have already satisfied Codex account, authentication, and local installation requirements outside Ralph.
+- Ralph should provide a consistent user-facing workflow across supported agents even if the underlying agent tools differ.
+- Codex support in this feature is intentionally limited to the main plan and build workflows; parallel-agent, worktree, and other advanced Codex run modes are deferred.

--- a/specs/010-codex-support/tasks.md
+++ b/specs/010-codex-support/tasks.md
@@ -1,0 +1,231 @@
+# Tasks: Codex Agent Support
+
+**Input**: Design documents from `specs/010-codex-support/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included. The plan and constitution require table-driven Go tests plus `go test ./...` and `go vet ./...` validation.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish config surfaces and Codex package scaffolding used by all stories.
+
+- [ ] T001 Add `AgentConfig` and `CodexConfig` plus defaults and validation rules to `internal/config/config.go`
+- [ ] T002 [P] Update generated config scaffolding for `[agent]` and `[codex]` in `internal/config/scaffold.go` and `ralph.toml`
+- [ ] T003 [P] Add table-driven config and scaffold coverage for agent settings in `internal/config/config_test.go` and `internal/config/scaffold_test.go`
+- [ ] T004 Create Codex adapter package skeleton in `internal/codex/agent.go`, `internal/codex/parser.go`, and `internal/codex/parser_test.go`
+
+**Checkpoint**: Config and package scaffolding exist; all user stories can build on the same selection and adapter surfaces.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared agent metadata and agent-resolution plumbing required before any user story can be completed.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T005 Add `Agent` metadata to `internal/loop/event.go`, `internal/store/store.go`, and `internal/regent/state.go`
+- [ ] T006 [P] Add metadata round-trip coverage in `internal/store/jsonl_test.go` and `internal/regent/state_test.go`
+- [ ] T007 Implement effective-agent resolution and shared unsupported-flow guards in `cmd/ralph/execute.go`
+- [ ] T008 [P] Add `--agent` flag plumbing to supported commands in `cmd/ralph/commands.go` and registration coverage in `cmd/ralph/commands_test.go`
+- [ ] T009 [P] Make startup and loop messaging agent-agnostic in `internal/loop/loop.go` and `cmd/ralph/main.go`
+
+**Checkpoint**: Effective-agent selection, metadata fields, and command surfaces are in place for all stories.
+
+---
+
+## Phase 3: User Story 1 - Run Ralph with Codex for Main Flows (Priority: P1) 🎯 MVP
+
+**Goal**: A developer can run Codex in Ralph's supported single-run `plan`, `build`, and `run` flows with the same supervision and git lifecycle as Claude.
+
+**Independent Test**: Configure or override a run to use Codex, execute `ralph loop plan --agent codex --no-tui` or `ralph build --agent codex --no-tui`, and verify the session starts, streams structured progress, and completes through the normal loop flow.
+
+### Tests for User Story 1
+
+> Write these tests first. They must fail before implementation.
+
+- [ ] T010 [P] [US1] Write Codex subprocess and parser tests in `internal/codex/agent_test.go` and `internal/codex/parser_test.go`
+- [ ] T011 [P] [US1] Write supported-flow execution tests for Codex in `cmd/ralph/execute_test.go`
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Implement Codex JSONL event translation in `internal/codex/parser.go`
+- [ ] T013 [US1] Implement the `codex exec --json --full-auto --cd` runner in `internal/codex/agent.go`
+- [ ] T014 [US1] Wire the Codex adapter into supported single-run paths in `cmd/ralph/execute.go`
+- [ ] T015 [US1] Emit effective-agent metadata in live loop output from `internal/loop/loop.go` and `cmd/ralph/format.go`
+
+**Checkpoint**: Codex can drive Ralph's main single-run plan/build workflows end to end. MVP complete.
+
+---
+
+## Phase 4: User Story 2 - Choose the Agent Per Project or Run (Priority: P2)
+
+**Goal**: A developer can set a project default agent and override it per run, with the selected agent visible in stored and live status surfaces.
+
+**Independent Test**: Set one project to `agent.type = "codex"`, start a run without overrides, then start another run with `--agent claude` or `--agent codex` and verify precedence plus visibility in status/output.
+
+### Tests for User Story 2
+
+- [ ] T016 [P] [US2] Write project-default and flag-precedence tests in `internal/config/config_test.go` and `cmd/ralph/execute_test.go`
+- [ ] T017 [P] [US2] Write visibility and persisted-state tests in `internal/store/jsonl_test.go`, `internal/regent/state_test.go`, and `internal/tui/app_test.go`
+
+### Implementation for User Story 2
+
+- [ ] T018 [P] [US2] Implement project-default and per-run precedence handling in `internal/config/config.go` and `cmd/ralph/execute.go`
+- [ ] T019 [P] [US2] Persist effective-agent identity in `internal/store/jsonl.go` and `internal/regent/state.go`
+- [ ] T020 [US2] Surface the selected agent in user-visible status output in `cmd/ralph/execute.go`, `internal/tui/app.go`, and `internal/tui/panels/header.go`
+
+**Checkpoint**: Agent choice is durable, overrideable, and visible in both live and recorded run context.
+
+---
+
+## Phase 5: User Story 3 - Recover Quickly from Setup or Compatibility Problems (Priority: P3)
+
+**Goal**: Codex startup failures and unsupported workflow selections fail early with clear, actionable guidance.
+
+**Independent Test**: Attempt to start Codex when the binary is missing or when Codex is selected for an unsupported workflow such as `--worktree`, and verify Ralph exits before work starts with an actionable error.
+
+### Tests for User Story 3
+
+- [ ] T021 [P] [US3] Write unavailable-binary and unsupported-workflow tests in `cmd/ralph/execute_test.go` and `cmd/ralph/wiring_test.go`
+- [ ] T022 [P] [US3] Write Codex startup failure coverage in `internal/codex/agent_test.go`
+
+### Implementation for User Story 3
+
+- [ ] T023 [P] [US3] Validate Codex executable availability and startup failure handling in `internal/codex/agent.go`
+- [ ] T024 [P] [US3] Reject Codex for worktree and dashboard/orchestrator flows in `cmd/ralph/execute.go` and `cmd/ralph/wiring.go`
+- [ ] T025 [US3] Return actionable agent-selection and startup errors in `cmd/ralph/commands.go`, `cmd/ralph/main.go`, and `cmd/ralph/execute.go`
+
+**Checkpoint**: Misconfiguration and unsupported scope errors are clear, early, and safe.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, regression coverage, and final validation across all stories.
+
+- [ ] T026 [P] Update Codex setup and selection docs in `README.md` and `ralph.toml`
+- [ ] T027 [P] Validate example flows and expected results in `specs/010-codex-support/quickstart.md` and `specs/010-codex-support/contracts/cli-agent-selection.md`
+- [ ] T028 [P] Add regression coverage for unchanged Claude-default behavior in `cmd/ralph/execute_test.go` and `internal/loop/loop_test.go`
+- [ ] T029 Run final validation with `go test ./...` and `go vet ./...` from the repository root
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies; can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1; blocks all user stories
+- **US1 (Phase 3)**: Depends on Phase 2
+- **US2 (Phase 4)**: Depends on US1 because persistence and visibility build on a working Codex single-run path
+- **US3 (Phase 5)**: Depends on US1 because failure handling wraps the Codex adapter and supported-flow execution path
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Starts after Foundational; no dependencies on other stories
+- **US2 (P2)**: Depends on US1 runtime support and Foundational selection plumbing
+- **US3 (P3)**: Depends on US1 runtime support; can proceed independently of US2 after US1 is complete
+
+### Within Each User Story
+
+- Tests must be written and fail before implementation
+- Parser/adapter work before command integration
+- Persistence before UI/status visibility
+- Error detection before user-facing error copy polish
+
+### Parallel Opportunities
+
+- Phase 1: T002 and T003 can run in parallel
+- Phase 2: T006, T008, and T009 can run in parallel after T005/T007 planning is clear
+- US1: T010 and T011 can run in parallel
+- US2: T016 and T017 can run in parallel; T018 and T019 can run in parallel after tests exist
+- US3: T021 and T022 can run in parallel; T023 and T024 can run in parallel after tests exist
+- Phase 6: T026, T027, and T028 can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```text
+# Parallel test work before Codex runtime implementation:
+T010: Write Codex subprocess and parser tests in internal/codex/agent_test.go and internal/codex/parser_test.go
+T011: Write supported-flow execution tests for Codex in cmd/ralph/execute_test.go
+```
+
+## Parallel Example: User Story 2
+
+```text
+# Parallel precedence and visibility work after US1 lands:
+T016: Write project-default and flag-precedence tests in internal/config/config_test.go and cmd/ralph/execute_test.go
+T017: Write visibility and persisted-state tests in internal/store/jsonl_test.go, internal/regent/state_test.go, and internal/tui/app_test.go
+T018: Implement precedence handling in internal/config/config.go and cmd/ralph/execute.go
+T019: Persist agent identity in internal/store/jsonl.go and internal/regent/state.go
+```
+
+## Parallel Example: User Story 3
+
+```text
+# Parallel failure-path work after Codex runtime exists:
+T021: Write unavailable-binary and unsupported-workflow tests in cmd/ralph/execute_test.go and cmd/ralph/wiring_test.go
+T022: Write Codex startup failure coverage in internal/codex/agent_test.go
+T023: Validate Codex executable availability and startup failure handling in internal/codex/agent.go
+T024: Reject Codex for worktree and dashboard/orchestrator flows in cmd/ralph/execute.go and cmd/ralph/wiring.go
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **Stop and validate**: Run a Codex-backed `plan` or `build` flow independently
+5. Ship/demo the Codex single-run path as the first increment
+
+### Incremental Delivery
+
+1. Setup + Foundational: Config, metadata, and command surfaces ready
+2. Add US1: Codex main flows run end to end
+3. Add US2: Project default and per-run override become durable and visible
+4. Add US3: Setup and unsupported-flow failures become actionable
+5. Finish Polish: Docs, regression coverage, and full validation
+
+### Parallel Team Strategy
+
+1. One engineer completes Setup and Foundational tasks first
+2. After Phase 2, one engineer can own Codex runtime (US1) while another prepares precedence/visibility tests (US2)
+3. Once US1 lands, a separate engineer can implement unsupported-flow protections and startup error handling (US3)
+
+---
+
+## Task Count Summary
+
+| Phase | Scope | Tasks |
+|-------|-------|-------|
+| Phase 1 | Setup | 4 |
+| Phase 2 | Foundational | 5 |
+| Phase 3 | US1 | 6 |
+| Phase 4 | US2 | 5 |
+| Phase 5 | US3 | 5 |
+| Phase 6 | Polish | 4 |
+| **Total** |  | **29** |
+
+## Notes
+
+- Every task follows the required checklist format with checkbox, task ID, optional `[P]`, optional story label, and explicit file path
+- The suggested MVP scope is **User Story 1 only** after Setup and Foundational phases
+- US2 and US3 remain independently valuable follow-on increments once the Codex runtime path exists

--- a/specs/010-codex-support/tasks.md
+++ b/specs/010-codex-support/tasks.md
@@ -19,10 +19,10 @@
 
 **Purpose**: Establish config surfaces and Codex package scaffolding used by all stories.
 
-- [ ] T001 Add `AgentConfig` and `CodexConfig` plus defaults and validation rules to `internal/config/config.go`
-- [ ] T002 [P] Update generated config scaffolding for `[agent]` and `[codex]` in `internal/config/scaffold.go` and `ralph.toml`
-- [ ] T003 [P] Add table-driven config and scaffold coverage for agent settings in `internal/config/config_test.go` and `internal/config/scaffold_test.go`
-- [ ] T004 Create Codex adapter package skeleton in `internal/codex/agent.go`, `internal/codex/parser.go`, and `internal/codex/parser_test.go`
+- [X] T001 Add `AgentConfig` and `CodexConfig` plus defaults and validation rules to `internal/config/config.go`
+- [X] T002 [P] Update generated config scaffolding for `[agent]` and `[codex]` in `internal/config/scaffold.go` and `ralph.toml`
+- [X] T003 [P] Add table-driven config and scaffold coverage for agent settings in `internal/config/config_test.go` and `internal/config/scaffold_test.go`
+- [X] T004 Create Codex adapter package skeleton in `internal/codex/agent.go`, `internal/codex/parser.go`, and `internal/codex/parser_test.go`
 
 **Checkpoint**: Config and package scaffolding exist; all user stories can build on the same selection and adapter surfaces.
 
@@ -34,11 +34,11 @@
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T005 Add `Agent` metadata to `internal/loop/event.go`, `internal/store/store.go`, and `internal/regent/state.go`
-- [ ] T006 [P] Add metadata round-trip coverage in `internal/store/jsonl_test.go` and `internal/regent/state_test.go`
-- [ ] T007 Implement effective-agent resolution and shared unsupported-flow guards in `cmd/ralph/execute.go`
-- [ ] T008 [P] Add `--agent` flag plumbing to supported commands in `cmd/ralph/commands.go` and registration coverage in `cmd/ralph/commands_test.go`
-- [ ] T009 [P] Make startup and loop messaging agent-agnostic in `internal/loop/loop.go` and `cmd/ralph/main.go`
+- [X] T005 Add `Agent` metadata to `internal/loop/event.go`, `internal/store/store.go`, and `internal/regent/state.go`
+- [X] T006 [P] Add metadata round-trip coverage in `internal/store/jsonl_test.go` and `internal/regent/state_test.go`
+- [X] T007 Implement effective-agent resolution and shared unsupported-flow guards in `cmd/ralph/execute.go`
+- [X] T008 [P] Add `--agent` flag plumbing to supported commands in `cmd/ralph/commands.go` and registration coverage in `cmd/ralph/commands_test.go`
+- [X] T009 [P] Make startup and loop messaging agent-agnostic in `internal/loop/loop.go` and `cmd/ralph/main.go`
 
 **Checkpoint**: Effective-agent selection, metadata fields, and command surfaces are in place for all stories.
 
@@ -54,15 +54,15 @@
 
 > Write these tests first. They must fail before implementation.
 
-- [ ] T010 [P] [US1] Write Codex subprocess and parser tests in `internal/codex/agent_test.go` and `internal/codex/parser_test.go`
-- [ ] T011 [P] [US1] Write supported-flow execution tests for Codex in `cmd/ralph/execute_test.go`
+- [X] T010 [P] [US1] Write Codex subprocess and parser tests in `internal/codex/agent_test.go` and `internal/codex/parser_test.go`
+- [X] T011 [P] [US1] Write supported-flow execution tests for Codex in `cmd/ralph/execute_test.go`
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Implement Codex JSONL event translation in `internal/codex/parser.go`
-- [ ] T013 [US1] Implement the `codex exec --json --full-auto --cd` runner in `internal/codex/agent.go`
-- [ ] T014 [US1] Wire the Codex adapter into supported single-run paths in `cmd/ralph/execute.go`
-- [ ] T015 [US1] Emit effective-agent metadata in live loop output from `internal/loop/loop.go` and `cmd/ralph/format.go`
+- [X] T012 [US1] Implement Codex JSONL event translation in `internal/codex/parser.go`
+- [X] T013 [US1] Implement the `codex exec --json --full-auto --cd` runner in `internal/codex/agent.go`
+- [X] T014 [US1] Wire the Codex adapter into supported single-run paths in `cmd/ralph/execute.go`
+- [X] T015 [US1] Emit effective-agent metadata in live loop output from `internal/loop/loop.go` and `cmd/ralph/format.go`
 
 **Checkpoint**: Codex can drive Ralph's main single-run plan/build workflows end to end. MVP complete.
 
@@ -76,14 +76,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T016 [P] [US2] Write project-default and flag-precedence tests in `internal/config/config_test.go` and `cmd/ralph/execute_test.go`
-- [ ] T017 [P] [US2] Write visibility and persisted-state tests in `internal/store/jsonl_test.go`, `internal/regent/state_test.go`, and `internal/tui/app_test.go`
+- [X] T016 [P] [US2] Write project-default and flag-precedence tests in `internal/config/config_test.go` and `cmd/ralph/execute_test.go`
+- [X] T017 [P] [US2] Write visibility and persisted-state tests in `internal/store/jsonl_test.go`, `internal/regent/state_test.go`, and `internal/tui/app_test.go`
 
 ### Implementation for User Story 2
 
-- [ ] T018 [P] [US2] Implement project-default and per-run precedence handling in `internal/config/config.go` and `cmd/ralph/execute.go`
-- [ ] T019 [P] [US2] Persist effective-agent identity in `internal/store/jsonl.go` and `internal/regent/state.go`
-- [ ] T020 [US2] Surface the selected agent in user-visible status output in `cmd/ralph/execute.go`, `internal/tui/app.go`, and `internal/tui/panels/header.go`
+- [X] T018 [P] [US2] Implement project-default and per-run precedence handling in `internal/config/config.go` and `cmd/ralph/execute.go`
+- [X] T019 [P] [US2] Persist effective-agent identity in `internal/store/jsonl.go` and `internal/regent/state.go`
+- [X] T020 [US2] Surface the selected agent in user-visible status output in `cmd/ralph/execute.go`, `internal/tui/app.go`, and `internal/tui/panels/header.go`
 
 **Checkpoint**: Agent choice is durable, overrideable, and visible in both live and recorded run context.
 
@@ -97,14 +97,14 @@
 
 ### Tests for User Story 3
 
-- [ ] T021 [P] [US3] Write unavailable-binary and unsupported-workflow tests in `cmd/ralph/execute_test.go` and `cmd/ralph/wiring_test.go`
-- [ ] T022 [P] [US3] Write Codex startup failure coverage in `internal/codex/agent_test.go`
+- [X] T021 [P] [US3] Write unavailable-binary and unsupported-workflow tests in `cmd/ralph/execute_test.go` and `cmd/ralph/wiring_test.go`
+- [X] T022 [P] [US3] Write Codex startup failure coverage in `internal/codex/agent_test.go`
 
 ### Implementation for User Story 3
 
-- [ ] T023 [P] [US3] Validate Codex executable availability and startup failure handling in `internal/codex/agent.go`
-- [ ] T024 [P] [US3] Reject Codex for worktree and dashboard/orchestrator flows in `cmd/ralph/execute.go` and `cmd/ralph/wiring.go`
-- [ ] T025 [US3] Return actionable agent-selection and startup errors in `cmd/ralph/commands.go`, `cmd/ralph/main.go`, and `cmd/ralph/execute.go`
+- [X] T023 [P] [US3] Validate Codex executable availability and startup failure handling in `internal/codex/agent.go`
+- [X] T024 [P] [US3] Reject Codex for worktree and dashboard/orchestrator flows in `cmd/ralph/execute.go` and `cmd/ralph/wiring.go`
+- [X] T025 [US3] Return actionable agent-selection and startup errors in `cmd/ralph/commands.go`, `cmd/ralph/main.go`, and `cmd/ralph/execute.go`
 
 **Checkpoint**: Misconfiguration and unsupported scope errors are clear, early, and safe.
 
@@ -114,10 +114,10 @@
 
 **Purpose**: Documentation, regression coverage, and final validation across all stories.
 
-- [ ] T026 [P] Update Codex setup and selection docs in `README.md` and `ralph.toml`
-- [ ] T027 [P] Validate example flows and expected results in `specs/010-codex-support/quickstart.md` and `specs/010-codex-support/contracts/cli-agent-selection.md`
-- [ ] T028 [P] Add regression coverage for unchanged Claude-default behavior in `cmd/ralph/execute_test.go` and `internal/loop/loop_test.go`
-- [ ] T029 Run final validation with `go test ./...` and `go vet ./...` from the repository root
+- [X] T026 [P] Update Codex setup and selection docs in `README.md` and `ralph.toml`
+- [X] T027 [P] Validate example flows and expected results in `specs/010-codex-support/quickstart.md` and `specs/010-codex-support/contracts/cli-agent-selection.md`
+- [X] T028 [P] Add regression coverage for unchanged Claude-default behavior in `cmd/ralph/execute_test.go` and `internal/loop/loop_test.go`
+- [X] T029 Run final validation with `go test ./...` and `go vet ./...` from the repository root
 
 ---
 

--- a/specs/develop/plan.md
+++ b/specs/develop/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |


### PR DESCRIPTION
## Summary
- add Codex as a supported Ralph agent with config selection, runtime integration, persisted metadata, status/TUI visibility, and release/docs updates
- fix stale Regent status reporting so unfinished runs only show as running while the recorded Ralph PID is still alive
- include the Speckit workflow, command, and extension assets introduced alongside this feature work

## Validation
- go test ./... -count=1 -timeout 300s
- go vet ./...
- go build ./...
- smoke-tested go run ./cmd/ralph --help, --version, status, loop build --help, and dashboard startup